### PR TITLE
Add missing mailto: to email link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
                       </ul>
                     </p>
                     <p>
-                      Please respect the conference's <a href="{{site.baseurl}}/codeofconduct">code of conduct</a>. If you encounter any problems, don't hesitate to contact the team via <a href="https://t.me/sotm2018">Telegram</a>, <a href="https://wiki.openstreetmap.org/wiki/State_of_the_Map_2020#IRC">IRC</a> or <a href="sotm@openstreetmap.org">email</a> to receive the personal contact details of our code of conduct team.
+                      Please respect the conference's <a href="{{site.baseurl}}/codeofconduct">code of conduct</a>. If you encounter any problems, don't hesitate to contact the team via <a href="https://t.me/sotm2018">Telegram</a>, <a href="https://wiki.openstreetmap.org/wiki/State_of_the_Map_2020#IRC">IRC</a> or <a href="mailto:sotm@openstreetmap.org">email</a> to receive the personal contact details of our code of conduct team.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Otherwise, clicking on it results in a "404 Not Found" error.