### PR TITLE
Add static export of Q&A pads

### DIFF
--- a/_includes/css/sotm2020.css
+++ b/_includes/css/sotm2020.css
@@ -910,3 +910,27 @@ h2.abstract-subtitle {
     font-weight: bold;
     padding-bottom: 10px;
 }
+
+/* Q&A
+--------------------------------------*/
+.qa-page .disclaimer {
+    font-style: italic;
+    padding-right: 1em;
+}
+
+@media only screen and (max-width:767px) {
+    .qa-page .disclaimer {
+        padding-right: 0;
+    }
+}
+
+.qa-content ol {
+    list-style-type: none;
+    list-style-position: outside;
+    counter-reset: item;
+}
+
+.qa-content ol > li:before {
+    counter-increment: item;
+    content: counters(item, ".") ". ";
+}

--- a/_layouts/qa.html
+++ b/_layouts/qa.html
@@ -1,0 +1,28 @@
+---
+layout: default
+color: no-logo program-page
+color: dark-nav
+---
+<div class='keyline-top pad8y qa-page'>
+  <div class='limiter'>
+    <div class='pad4y col12 clearfix prose min-height'>
+      <h1>Questions & Answers - {{page.title}}</h1>
+
+      <section class='col3'>
+        <p class="disclaimer">
+          Disclaimer: This is an archived version of the once interactive
+          session pad with content from conference attendees. Please note that
+          some information was lost during the transformation (i.e. the edit
+          history, user colours, the chat and some formatting).
+        </p>
+
+        <p>
+          <a href="/sessions/{{page.code}}" title="Page of the session with abstract and video">Back to session page</a>
+        </p>
+      </section>
+      <section class='col9 qa-content'>
+        {{content}}
+      </section>
+    </div>
+  </div>
+</div>

--- a/_layouts/session.html
+++ b/_layouts/session.html
@@ -32,7 +32,7 @@ color: dark-nav
         <hr class="space-right4">
 
         <p>
-          <a href="{{page.pad}}" title="interactive session pad for discussions, questions and answers, extra content, etc. about this session">session pad</a>
+          <a href="/sessions/qa/{{page.code}}" title="archived session pad with discussions, questions and answers, extra content, etc. about this session">session pad</a>
         </p>
 
         <hr class="space-right4">

--- a/_layouts/session_academic.html
+++ b/_layouts/session_academic.html
@@ -32,7 +32,7 @@ color: dark-nav
         <hr class="space-right4">
 
         <p>
-          <a href="{{page.pad}}" title="interactive session pad for discussions, questions and answers, extra content, etc. about this session">session pad</a>
+          <a href="/sessions/qa/{{page.code}}" title="archived session pad with discussions, questions and answers, extra content, etc. about this session">session pad</a>
         </p>
 
         <hr class="space-right4">

--- a/sessions/qa/373NDC.md
+++ b/sessions/qa/373NDC.md
@@ -1,0 +1,128 @@
+---
+layout: qa
+title: "How to publish a multi-modal journey app based on OSM with Trufi App"
+code: "373NDC"
+---
+
+
+Please feel free to start writing questions before the end of the talk
+and remind to rename yourself :)
+Please keep a copy of the previous language before translating to
+another language.
+
+Speaker: Christoph Hanser (
+<https://wiki.openstreetmap.org/wiki/User:Chanser> ) & Samuel Rioja
+<https://www.trufi-association.org/>
+Chair: Lorenzo Stucchi (@LorenzoStucchi)
+
+**Questions:**
+
+1.  \[DONE\] GTFS (General Transit Feed Specification) standard demand
+    bus stop, do you work with this standard? How manage this
+    requirement?
+    1.  ANSWER: Yes, we are working with GTFS data. For informal bus
+        routes we build virtual bus stops on every crossing - Sören
+        (Trufi)
+    2.  Are you planning to support GTFS-Flex?, Felix
+        1.  Yes, definitely. Actually, we are running Trufi App in Addis
+            Ababa already with GTFS Flex and want to migrate the other
+            cities as well.
+2.  \[DONE\] How do you create bus routes ?
+    1.  if I understood well, you create GTFS from OSM routes ?
+    2.  Do you create routes manually with JOSM ??
+3.  \[DONE\] What are "Digital Principles"? (The speaker mentioned that
+    the app was developed "along Digital Princples, if you know what I
+    mean".) -- das-g
+    1.  you can see <https://digitalprinciples.org/>
+        1.  (thanks!) -- das-g
+4.  \[DONE\] Which countries in Africa are using it?
+    1.   (Ghana and Ethiopia)
+5.  \[DONE\] Anyone in Tanzania?
+    1.  Not yet, please contact us! - Christoph
+6.  \[DONE\] What level of technical expertise do you need?
+    1.  ANSWER: The tech team must be able to develop in Dart/Flutter or
+        able to learn it - Sören (Trufi)
+7.  \[DONE\] It was mentioned that the app is customized / localized for
+    local communities. When travelling several Trufi-enabled places
+    (cities, countries), do I have to download a separate app for each,
+    or is there one I could use everywhere? -- das-g
+8.  \[DONE\] Will the app(s) be available of F-Droid?
+    <https://f-droid.org/> -- das-g
+    1.  Yes, please contact me if you want to help us to publish it on
+        F-Droid!
+    2.  We made a try but failed and haven't tried again. - Christoph
+9.  \[DONE\] Why are there multiple apps (forks of the original) instead
+    of one (localized) brand?
+10. How do you deal with the very chaotic and different ways to map
+    public transport in OSM? If you have your own model: Is it available
+    in the OSM-wiki or elsewhere?
+    1.  We have a guideline on how we do it:
+        <https://www.trufi-association.org/projects/the-ultimate-guide/>
+    2.  Sören will talk about this in his talk at 20:00 UTC - Christoph
+11. How can you collaborate with companies likke WhereIsMyTransport from
+    South Africa to target the coverage for more cities?
+    1.  Our data is Open Data from OSM and WhereIsMyTransport isn't
+        -Enock
+    2.  We could collaborate with companies like WhereIsMyTransport,
+        because our App could be an add-on to their backend - of course,
+        we would prefer an open source backend. - Christoph
+12. \[DONE\] What does the name "trufi" mean / derive from? -- das-g
+    1.  Taxi de Ruta Fija :)
+    2.  From Bolivia - Enock, Meaning??
+13.  \[DONE\] Are there issues with internet connectivity in some places
+    that the busses go? - Gregory +1
+    1.  Yes - unfortunately, our app requires right now internet for the
+        search with OpenTripPlanner Server. - Christoph
+14. How is market penetration of the drivers app?
+    1.  Not yet - we look for a funding to finalize it. - Christoph
+15. Will the app help the drivers to find their way?  --- Sometimes the
+    driver in the villages does not know the exact route.
+    1.  What do you mean with "find their way"?
+        1.  Yes, but most important share GPS coordinates so that users
+            know, when the next bus comes.
+16. Can I see the vehicles in realtime? Like uber vehicle?
+    1.  In the future :) - Enock
+        1.  Yes, with the driver app. - Christoph
+17. Are the informations only useable on a smartphone or on a normal PC
+    as well?
+    1.  Only smartphone right now. - Christoph
+18. This app is compatible with the relations of transport created in
+    openstreetmap?
+    <https://wiki.openstreetmap.org/wiki/Key:public_transport>
+    1.  Yes! Using osm2gtfs you have a ready GTFS for OTP - Enock
+        1.  Exactly - that's what we build on. OSM2GTFS is a good option
+            and our own tool, published on Github.
+19. Do you think managing (mapping and keeping it updated) bus routes in
+    OSM is sustainable? - wille
+    1.  Yes, I think it is sustainable - Wille, could you write me, why
+        not? - Christoph
+        1.  In some places routes change too much. It's difficult to map
+            with relations in OSM, it costs time to be reviewing all
+            changes and assure information is reliable. Maybe it's a
+            good solution if you don't have official data.
+            1.  Yes, that's a challenge. Therefore, we need a lot of
+                community efforts. Sören will show later how to do the
+                work with JOSM.
+            2.  Users can also say, when routes are wrong or missing and
+                track their journey. With many of these trackings, we
+                want to establish a process to get curated routes to OSM
+                to keep it up2date.
+            3.  BTW, we only work in places without official data. -
+                Christoph
+20. In bad shape here in central Taiwan
+    1.  Let's clean it up together :) - Christoph
+21. in big cities) Don't bus companies give GTFS files to Google? Well
+    ask them for an extra copy.
+    1.  Yes, cities with digitizes public transport often already have
+        GTFS. That is of course the easy start for Trufi :)
+    2.  By the way, TRUFI can help maintaining the GTFS accurate and
+        up-to-date, with the user feedback on missing or outdated
+        routes. - Christoph
+
+
+
+**Comments:**
+
+1.   Kampala
+2.  Thanks for the answers to Christoph and Sören. :-)
+

--- a/sessions/qa/3AJAEF.md
+++ b/sessions/qa/3AJAEF.md
@@ -1,0 +1,34 @@
+---
+layout: qa
+title: "MapImpact: Mapping and social researchs by students in Cusco, Perú"
+code: "3AJAEF"
+---
+
+**Add questions here** *- if you want to please leave your name/OSM
+username and country*
+
+
+-   \[ANSWERED\] Did you include boys in the project as well? Why?
+-   \[ANSWERED\] How do you think you could help other schools to do
+    this internationally?
+-   \[ANSWERED\] As a Cusquenan woman, what impact do you think this can
+    have in the future?
+-   \[ANSWERED\] Wow, this is a really amazing example of how women and
+    girls can be involved in mapping. What is the biggest barrier you
+    have faced in training women and girls to map?+1
+-   what are the opportunities in training women and girls and have you
+    seen changes in confidence ito of their attitude to gender based
+    violence / other gender issues?
+-   \[ANSWERED\] Any **transgender** participation / discussion?
+
+
+
+Comments
+
+
+-   Great project! Reminded me of this other project, might be
+    interesting to you: <http://citydigits.org/> (or maybe you already
+    know about it :))
+-   Amazing project and looking forward to learning more about it! 
+    Anni - rosymaps | chicago usa
+

--- a/sessions/qa/3DMDQK.md
+++ b/sessions/qa/3DMDQK.md
@@ -1,0 +1,26 @@
+---
+layout: qa
+title: "Economy, Human, and Policy Impact on Mapping in Public Sector"
+code: "3DMDQK"
+---
+
+Add questions here
+
+1.  what addressing standards were used to provide addresses and unique
+    permanent codes for plotted buildings. Have you considered using
+    Open Location Codes from Google?
+2.  Is much data a government secret there?
+3.  So 30k KM is \_proposed\_ fiber network, so how much fiber now?
+4.  LSG=?
+5.  (Thanks, very interesting presentation!) How did you find, recruit,
+    and train 6,000 mappers? (for the first project you mentionned)
+
+
+
+
+
+<http://jidanni.org/geo/taipower/> are some neat power pole label number
+examples.
+
+<https://openinframap.org/> are neat power networks.
+

--- a/sessions/qa/3FNPY7.md
+++ b/sessions/qa/3FNPY7.md
@@ -1,0 +1,65 @@
+---
+layout: qa
+title: "Ranks for Rendering"
+code: "3FNPY7"
+---
+
+Add questions here
+
+1.  What are the rules for using third party data in OSM?
+2.  If OSM features are tagged with their Wikidata items, can you use
+    data stored in Wikidata to influence ranking? For example, number of
+    passengers for airports. +1
+3.  With increasing render options, do render managers share these
+    learnings easily?
+4.  Do you think that using vector tiles would help improve the
+    cartography? Or is the solution to add better ranks and to just keep
+    working on it?
+    1.  thanks for the answer! just putting it here for anyone's benefit
+        1.  ANSWER: the cartography problems still exist whether you use
+            raster tiles or vector tiles
+5.  There are railway stations with airport IATA codes (e.g. New York
+    stations). The use of IATA code to enhance rendering becomes hard to
+    apply in some cases.
+6.  Could you use the number of terminals to classify airport
+    importance?
+7.  Rendering of waterways labels is very hard to achieve because of the
+    already explained reasons. Since centuries, the labeling of
+    waterways based on lenght/size/flow is a basic part of a map. How to
+    solve this using OSM data?
+8.  Would it be so bad to have mappers record a relative importance,
+    something like a "scale\_rank" or so?
+    1.  Isn't this going back to the old debate about adding subjective
+        data into OSM? Mappers are still complaining about the
+        smoothness=\* tag.
+9.  Have you considered the number of gates within an airport area for
+    estimate its importance?
+10. Could you make the ranking relative to the highest visible rank in
+    the area rendered?
+
+
+
+-   Feedback (not a question) - Thank you for the interesting talk.
+    <https://github.com/Wikidata/Wikidata-Toolkit> may be interesting
+    for importing wikidata into PostgreSQL (unsure about the performance
+    of this tool). <https://wiki.openstreetmap.org/wiki/Wikidata> lists
+    tools and there was a talk last year:
+    <https://2019.stateofthemap.org/attachments/GUUUYW_OpenStreetMap_and_Wikidata_-_Awesome_Together.pdf>
+    +1, thanks! (it also mentions some concerns around data licensing,
+    which could be important) (which in my regard should be addressed
+    ASAP ;-\] it'd be so nice to have WIkidata and OSM in-sync)
+    -   The 2 licenses are so far away from each other. I don't see this
+        happening. Yeah :-(
+        -   But it's mostly an issue if you want to move data from one
+            to the other. If you want to use a Wikidata property to
+            guide your rendering, I don't think it's a stumbling block.
+            -   My perspective is mostly from the WIkidata Query Service
+                (WDQS), in which it would be nice to have OSM data over
+                there.
+                -   You can, as long as you give credit, can't you?
+                    -   From how I understand the discussion (see Wiki
+                        link above), import is disallowed. Linkage OK.
+                        (Before I lose you, do you have other info, or
+                        another understanding?)
+-   Congrats Michael, well done!!+5
+

--- a/sessions/qa/7LWKCA.md
+++ b/sessions/qa/7LWKCA.md
@@ -1,0 +1,23 @@
+---
+layout: qa
+title: "OSM Quiz"
+code: "7LWKCA"
+---
+
+Interesting questions about OpenStreetMap, details will be here....
+
+<s>Go to</s> [<s>https://myquiz.org</s>](https://myquiz.org) <s>type
+446594</s>
+
+
+-   -   **Post conference update: The quiz can be played in
+        single-player mode on:**
+    -   [**https://zverik.github.io/sotm2020-quiz/**](https://zverik.github.io/sotm2020-quiz/)
+
+
+<span class="underline">Questions:</span>
+Can you share the questions and answers in textual format. So we can
+reploy the quiz on social media or local events? Thx. +1
+
+<s>Next year ask: who lives at the OSM Corporate Towers?</s>
+

--- a/sessions/qa/8JQ7PY.md
+++ b/sessions/qa/8JQ7PY.md
@@ -1,0 +1,126 @@
+---
+layout: qa
+title: "Drones for Community Mapping"
+code: "8JQ7PY"
+---
+
+1.  Are your drone images also being uploaded to Wikimedia Commons, for
+    use on Wikipedia? - Andy Mabbett, @pigsonthewing
+    1.  Not currently, but many are posted on OpenAerialMap under open
+        licenses. -Eugene
+    2.  this the imagery in the slide:
+        <https://map.openaerialmap.org/#/121.13703299999999,16.93503259011358,17/square/13230132221/5d29ec177a18fd0005e2978e?resolution=high&_k=kgkfae>
+    3.  Arenda imagery:
+        <https://map.openaerialmap.org/#/121.11188650131226,14.537061956768639,15/square/13230312200133113/5dad0e1c16c43b00058d0262?resolution=high&_k=kizu9i>
+        -maning
+2.  How do you produce DTM, are you sing Pix4D and what are the quick
+    procedure
+    1.  Yep! I used Pix4D to generate DTM. You can check this diary
+        entry I did for the Lupang Arenda example:
+        <https://www.openstreetmap.org/user/geoleighyers/diary/391138>
+3.  Is there open source software for processing drone images?  Pix4d is
+    not open source.
+    1.  Yes, you can OpenDroneMap which is opensource. -maning &lt;3
+    2.  do you have any exeperionce
+        1.  The OSM community in the Philippines have a bit of
+            experience using OpenDroneMap and we are now experimenting
+            with various settings to try and generate optimal orthophoto
+            maps.
+4.  Do you have the base map of Batad uploaded online somewhere?
+    1.  Yep, you can check here:
+        <https://map.openaerialmap.org/#/121.13703299999999,16.93503259011358,17/square/13230132221/5d29ec177a18fd0005e2978e?resolution=high&_k=kgkfae>
+5.  This is awesome work! What were the reactions of the local
+    communities that you worked with? Were they generally cooperative?
+    Did they like the output when you shared it with them?
+    1.  For Batad, they do not like drones in the area because it was
+        noisy. But after the team explained it to the people, they were
+        okay with it. We explained as much as we can why we need to get
+        the data for research purposes and for their use as well.
+    2.  For Lupang Arenda, the drone mapping was actually a request of
+        the local government and they are now using the results of
+        mapping in OSM as part of their rendering of public services.
+        great to hear, thanks!
+    3.  more info about this community collab:
+        <https://github.com/OSMPH/papercut_fix/issues/54>
+        1.  thanks! great to see that there's a lot of discussion about
+            this!
+6.  Are there privacy concerns (in case individual human beings are
+    visible on the images) - do you blur these images, or ask people for
+    their consent?
+    1.  the 10cm resolution is not sharp enough to identify faces/people
+        1.  Yep I agree.
+7.  Is there any manual work for removing buildings for DTM, or
+    everything done by software.
+    1.  To enhance DTM data, WhiteBoxTools' RemoveOffTerrainObjects
+        module was recommended by a colleague.
+    2.  This is done automatically by software. Note that DTM is not
+        super accurate because it requires the software recognizing
+        trees and buildings and this is not very accurate. But the DSM
+        is useful.
+        1.  So the DTM is calculated from parallax between images?
+            1.  Yes! Pix4D and OpenDroneMap uses computer vision
+                techniques to determine the "3D" shapes of objects and
+                uses that to calculate the DSM.
+8.  Are there privacy concerns about objects visible on private ground
+    (in backyards, e.g.) not visible from the street level?
+    1.  In the works that I've done, we have proper coordination with
+        the government officials down to the local community leaders to
+        explain what we're collecting. As much as possible we
+        communicate with the community what we're doing and collecting.
+        So far, I haven't had this before. - Leigh
+9.  Do you have any equipments to adjust positioning like RTK or
+    something?
+    1.  The drone itself has GPS capabilities to get the XYZ values. If
+        the project / area requires higher accuracy in horizontal /
+        vertical location, GPS Survey or adding GPS markers will help.
+    2.  We only rely on the GPS/GNSS technology included inside the
+        drones.
+10. Great work! How do you choose locations/projects? What will be your
+    next project?
+    1.  Usually from friends from the geospatial community ask us to map
+        out areas. I team up with other drone pilots, OpenStreetMap PH
+        community or involve Philippines Flying Labs to do the mapping. 
+        Currently, I don't have a next project due to the Corona Virus
+        pandemic. Hopefully by next year, I can map again.
+11. How much complex to geo-reference drones' shots?
+    1.  All drone captured images have the location in its exif
+        metadata.  All images can just be in a single directory and the
+        software can take care of the stitching and georeferencing. 
+        This is the same for proprietary and open source tools.
+    2.  There are a few approaches to improve quality like taking
+        nadir/perpendicular + oblique.  But in most cases, nadir images
+        with 60-80% overlap will generate good results. -maning
+        1.  Thanks for this sir!
+12. What's the cost of such drones?
+    1.  Oh it's such a huge range! It ranges from 1500 USD to 25,000
+        USD. hehe. - Leigh
+13. What is your message for girls all around the world who want to
+    learn to fly a drone?
+    1.  Go fly and enjoy it! Don't be afraid of the technicalities of
+        it. :)
+    2.  Go fly, and enjoy it (answer from Leigh) If people give you
+        reasons not to, don't listen to them too hard (indiebio)
+        1.  Why not "listen to them if they provide a reasonable
+            explanation, and then make an informed decision taking into
+            account this information" Would this require a different
+            answer for women vs men?
+            1.  (I'm a girl and I would think yes - indiebio)
+            2.  There is good reason to encourage different groups of
+                people, but that's a question for a diversity talk
+                (Gregory).
+
+
+
+-   You are an inspiration for women all over our communities and seeing
+    you giving a talk about a highly technical topic gives us
+    motivation.
+-   Thank You for the talk, and your time working on this project -
+    Natfoot
+-   I need to do more of this. Done quite a bit of the photogrametery
+    simalar to pix4D from the ground using a poleand a camera. GoPro
+    cameras work well as they have a gps.  You can do it! happy to help
+    you as well!
+-   \[There's a problem with audio feedback - maybe encourage presenters
+    to use earphones?\]
+    -   yes, please
+

--- a/sessions/qa/9HLLQL.md
+++ b/sessions/qa/9HLLQL.md
@@ -1,0 +1,39 @@
+---
+layout: qa
+title: "Towards understanding the quality of OpenStreetMap contributions: Results of an intrinsic quality assessment of data for Mozambique"
+code: "9HLLQL"
+---
+
+DOI: <https://doi.org/10.5281/zenodo.3923042>
+
+**Questions**
+
+1.  \[Done\] Cameron Green - how would your results differ when compared
+    to other well mapped areas in Africa such as Tanzania?
+2.  \[Done\] Which technique do you think is moust useful to help in the
+    instrinsic studies - the K-Means or the other: PCA? Guy
+3.  \[DONE\] Was there a effort to plot cluster-member mapping against
+    automated error finding such as Keepright or Osmose? i.e. to find
+    errors in mapping tied to specific clusters? (Great job!)
+    -Greg\_Rose
+4.  \[DONE\] Did you try out other clustering methods aside from
+    K-means? Can you explain more about your reasoning for using a
+    parametric-based clustering method over a density-based clustering
+    method? - ardieorden
+    1.  got it, thanks!
+5.  \[Done\] Will you be continuing with this study, or is the project
+    now complete?
+6.  \[DONE\] Spatial data quality has 5 elements according to
+    <https://www150.statcan.gc.ca/n1/pub/92-195-x/2011001/other-autre/qua-eng.htm>
+    . On what data quality element are you after: Completeness?
+    Accurracy? other? ~Stefan K.
+
+
+
+**Comments**
+
+-   \[DONE\] Wow, awesome work -- YaguraStation
+-   \[DONE\] Really interesting analysis based upon the clustering of
+    users. It reflects other studies I have seen from other studies with
+    key contributors adding much data. Guy
+

--- a/sessions/qa/9L7U83.md
+++ b/sessions/qa/9L7U83.md
@@ -1,0 +1,60 @@
+---
+layout: qa
+title: "Health Facilities Import"
+code: "9L7U83"
+---
+
+Add questions here
+
+1.  Thank you for your interesting talk: I read in another place that
+    you, with RMSI, use AI-Road tracing in mapping projects in India. Is
+    this something you want to include in the project with the helath
+    care imports? And if yes, how could this work?
+2.  You mentioned converting data to GEoJSON before being imported. Why
+    that?
+3.  How do you do the conflation with data that already exists in OSM,
+    to make sure there are no doubles? How many health facilities were
+    already on OSM? Do you also look at health facilities that are on
+    OSM but missing from the official dataset, to see if they've been
+    closed, etc.? (moved from below) Is all diff'ing (of the incoming
+    gov data) manual or do you have tools?
+4.  How clean/reliable/complete is the gov data?
+5.  In NIN healthcare dataset I found ~1800 hospitals (district, sub and
+    categorized according to bed size) whereas in OSM 33.5k (6/8/2020,
+    amenity=hospital). Maybe you can elaborate on this discrepancy and
+    challenges of matching the indian healthcare system scheme with osm
+    tagging scheme.
+    1.  (First thanks for your intersting talk, it is very valuable to
+        me as I conduct some analysis on healthcare access in India.
+        Sorry if I missed it in the beginning when you were clarifying
+        sources for the import. I had a look into the NIN health
+        facility dataset. )
+6.  Could you please explain what is the exact meaning of
+    healthcare=centre? Are there physicians/doctors in them? Were health
+    facilities without doctors included in the import? And if yes how
+    were they tagged? (There was a recent discussion on the tagging list
+    which lead to an increased use of the recently created
+    amenity=health\_post tag to cover such entities).
+7.  Good to see that health facilities in India is improved,it will be
+    good if all the rural areas are covered
+8.  India is a huge country - how do you ensure you will find local
+    contributors to validate and perform the import?
+9.  You showed an example (JOSM screenshot) where healthcare=centre tag
+    was added, but amenity=hospital was removed. Why was the amenity tag
+    removed?
+10. Have you collaborated with Healthsites (www.healthsites.io) at all?
+    1.     ^^^^ to question author: Do Healthsites add data at all?
+        Everytime I check things like phone nr, website etc are empty.
+11. did u have special autorisation from the governement or Ministry of
+    Health to include all data in osm ?
+12. I'm working on the same project in my country and I'm adding one by
+    one and it is more secure , what di u think ?
+13. Great talk, thankyou :-)
+14. Good to see that rmsi is improving the heatlth facilities in india
+    :-)
+
+
+*we didn't have enough time to go through all questions. if your
+question was not answered in the live q&a part of the session, please
+contact the speaker directly. thank you for the interest!*
+

--- a/sessions/qa/AA8RXP.md
+++ b/sessions/qa/AA8RXP.md
@@ -1,0 +1,93 @@
+---
+layout: qa
+title: "Creating an open data ecosystem for reviews of places and more"
+code: "AA8RXP"
+---
+
+**Add questions here:**
+
+
+1.  <s>How can you guarantee reliability of data with pseudonymous
+    users?</s>
+2.  How can I add reviews to my app? Has anyone built an app (next to
+    *mangrove.reviews*), or is there a list?
+    1.  A: We are chatting with a projects, but no proper integrations
+        yet. You can check out <https://castle-map.infs.ch/> which just
+        leads you to the current web app after clicking "Review Object"
+3.  What existing open-content review systems did you examine, before
+    starting this one? Why were they not adequate? (e.g.
+    <https://github.com/eloquence/lib.reviews> , osmand place reviews)
+4.  Where can I find more information (online) about Open Reviews
+    Association?
+    1.  A: See the website: <https://open-reviews.net/>
+5.  How do you handle the lack of stable unique identifier in OSM? (see
+    <https://wiki.openstreetmap.org/wiki/Overpass_API/Permanent_ID)>
+    1.  A: We make use of a Geo URI (
+        <https://en.wikipedia.org/wiki/Geo_URI_scheme> ) with a
+        reconciliation algorithm that looks at proximity of coordinates
+        and the place name.
+6.  <s>How are disputes and arbitration handled?</s>
+7.  <s>How can one contribute/push this?</s> \[answered\]
+8.  Does a central Open Review Identity Provider app for Android exist?
+    (I don't know how Android account setting integrations work, but if
+    it's not a thing already, I'd be excited to at least look into it.)
+    1.  A: It does not yet, it would be great to have someone to have a
+        look!
+9.  Let's say some \[jerk\] writes a review without ever visiting the
+    place. On Google and Facebook he site owner is helpless to fight
+    back and get it deleted usually (due to FB and Google being just too
+    big to get a word in edgewise.) Hope it won't end up this way too.
+    (Maybe 6.)
+    1.  A: If the review was left by a one-off user then its unlikely
+        that it will be treated as reliable by an algorithm. Otherwise
+        the place will need to recoup by getting good reviews. The issue
+        with these other platforms is that they start removing good
+        reviews since they say those are fraudulent (left by the owner),
+        which leads to a negative spiral.
+10. What type of things are up for review?
+    1.  A: Currently places, websites, books and companies. The standard
+        can be easily expanded as long as new open unique identifiers
+        are found.
+11. What about reviews for services? Could be interesting for cities and
+    other public services - as well as for all services perhaps.
+
+
+**Comments**
+
+-   Your Open Reviews work is so important--thanks! Yelp and Google, for
+    example, filter and order results based on advertising customers and
+    those who pay more.
+    -   A: Thanks!
+-   very good and important - I often see new users leaving reviews of
+    places missunderstanding the notes - so I think this is a very basic
+    and important feature that OSM is lacking today
+    -   A: Sounds great, do you think it would be relevant to introduce
+        this functionality directly into OSM?
+-   Now that the OpenPlaceReviews project is indefinitely on hold, it is
+    great to see a new project. (That has some benefits over OPR.)
+-   Agreed! Working on fully FOSS/Open Data travel assistance software
+    this is one of the missing pieces for us, will look into integrating
+    this :)
+    -   A: Perfect, please get in touch.
+-   I'm a CouchSurfing Host... don't count me out. Yup, even non-profit
+    indiviuals get reviews. (Hmmm, so one must not consider me "just
+    part of the CS website". And somewhat different that an AirBnB
+    for-profit host.)
+    -   A: Let us know if you can think how it can work well for this
+        case! (On a separate note CouchSurfing might be a nice
+        integration partner.)
+-   Better add a "Owner rebuttal section": "He said my place didn't have
+    a hot shower. Nonsense!"
+    -   A: Yep, thats the idea with comments.
+-   Awesome talk, thanks!
+    -   A: Cheers!
+-   Don't say e.g., "minimum 50 characters", most users will "balk out."
+    -   A: One can even just leave a rating, no text at all :)
+
+
+**Information about the Open Reviews Association and the tech**:
+<https://open-reviews.net/>
+**Link to the presentation slides:**
+<https://docs.google.com/presentation/d/1PplC89uEekFp6HYmB2N63ueDGdr3rV0oql60NyPTKb0/edit?usp=sharing>
+
+

--- a/sessions/qa/AWT7K8.md
+++ b/sessions/qa/AWT7K8.md
@@ -1,0 +1,98 @@
+---
+layout: qa
+title: "Gender Performance in OSM Mapping, Does It Matter?"
+code: "AWT7K8"
+---
+
+Speaker: Zainab Ramadhanis
+
+**Resources:**
+
+
+-   some research on diversity
+    -    <https://wiki.openstreetmap.org/wiki/Diversity>
+-   also see the Diversity and Inclusion working group
+    -   <https://wiki.osmfoundation.org/wiki/Diversity_and_Inclusion_Special_Committee>
+
+
+**Questions**
+
+
+1.  \[DONE\] How can you measure the men and (How do you know if osm
+    contributors are men or women?)
+    1.  How do you identify the sex of mappers in your analysis when  we
+        tend to use either nicknames or gender neutral short names. For
+        example Chris,  is that Christopher or Christine. Gender neutral
+        names are commonly used normal life outside of OSM
+2.  \[DONE\] What is the percentage of paid mappers in terms of
+    contribution and what is their rentention once project is done? -
+    Trudy
+3.  How can we use the research to for community retention?
+4.  So is the imbalance "bad and there should be a effort to correct
+    it", or, "accept it, their brains are different"?
+5.  How can we better measure non-technolgy contributions to OSM? -
+    heather
+6.  \[DONE\] Do you think there is a danger that mappers avoid telling
+    their gender (or setting a name that identifies their gender)
+    because there are thoughts that men and women map differently? --
+    Gregory
+7.  \[DONE\] Are there more differences between individual men and
+    between individual women than an average man and an average woman?
+8.  Do you first see the edit types and then go ahead to ping the users
+    to certify if the gender you identified is correct?
+9.  \[DONE\] Was there any difference in men and women's access to
+    technology and training?
+    1.  this was not formally asked in the survey
+10. \[DONE\] What are your suggestion for increasing the contribution of
+    woman in mapping activity? Would it be make the mapathon specific to
+    their needs? Or maybe make the tags/presets to specific to women?
+    1.  Or make mapping features particularly relevant to women/and
+        clearly demonstrate the impact of mapping?
+11. \[DONE\] How do you compute smoothness? It is something qualitative
+    or some metrics?
+12. Which part the world your research covers? All the world or only
+    some country?
+13. Since you're indonesian, maybe is that correct why you only split
+    gender into two categories ?  In my understanding Indonesia
+    recognizes 5. some of researchers using common surveys. not sure if
+    she consider that one.
+
+15\. \[DONE\] Is this research being published any where?
+
+**Comments**
+
+
+-   this reminds me of the study presented at SOTM in Brussels a few
+    years ago. we do need to see how we can do more data analysis and
+    connect it to community development/engagement, technology,  and /or
+    policy shifts/ - heather
+-   Love the work that has been put in to add subtitles to the talk too
+    :) - Jinal
+-   Surely there are many **<span class="underline">transgender</span>**
+    mappers here on OSM too.
+    -   Yes they will be categorized into either male or female when
+        making statistics.
+        -   OK, so we need a separate study.
+        -   So this study should differentiate *cisgender* vs.
+            *transgender.*..
+        -   they are those who aren't yet sure of their gender+1 - Trudy
+-   It is difficult to identify the sex of most mappers as we tend to
+    use either nicknames or gender neutral short names. For example
+    Chris,  is that Christopher or Christine
+-   <s>From previous talk we know many must be paid mappers...</s>
+-   OSM should introduce gender on their signup. form - first step to
+    diversity +1 - Trudy
+    -   Better be more than two...
+    -   and a prefer not to say option
+-   If anyone is interested in helping Crowd2map do more research into
+    this.  A previous survey is here
+    <https://drive.google.com/drive/u/0/search?q=crowd2map%20suvey>  (we
+    have more recent data to analyse)
+-   The Google form you mentioned sounds so old fashioned with only
+    \[x\]male, and \[x\]female, two boxes.
+    -   There was an option to self identify or not say, but no one
+        selected it
+-   You should put this topic on your future study. Maybe you wanna do a
+    further study like master or doctoral degree. OSM has evolved
+    nowadays, becomes more and more detailed and profound
+

--- a/sessions/qa/AXAUHX.md
+++ b/sessions/qa/AXAUHX.md
@@ -1,0 +1,52 @@
+---
+layout: qa
+title: "Opening"
+code: "AXAUHX"
+---
+<span class="underline">Questions pour la session d'ouverture</span>
+
+
+Ajoutez des questions ici
+
+-   Est-ce que ça va marcher? (Kirill, Russie)
+-   Devrions-nous ajouter notre nom ou l'anonymat est-il très bien? Vous
+    pouvez le changer en haut à droite, où le nombre de personnes est
+    affiché :)
+-   merci d'avoir fourni cet outil!
+-   C'est super, merci pour le travail acharné de coordination!
+-   Dans l'attente de cela!
+
+
+translated (auto using google)
+Add questions here
+
+-   Will it work? (Kirill, Russia)
+-   Should we add our name or is anonymity fine?
+-   You can change it at the top right, where the number of people is
+    displayed :) thank you for providing this tool! It's great, thanks
+    for the hard work of coordination!
+-   Pending that!
+
+
+
+-   Where are you guys talking from, England? S. Africa? I mean the
+    video faces. → moved below
+
+
+
+-   Do you have directions to the coffee station?? :). Do you mean
+    virtual coffee station? :)
+
+
+
+Bristol , Uk ... how does the translation work?  Volunteers, there is
+not an official way.
+Someone copy-pasted it from a translation engine probably
+
+Would be nice to know who the speakers are - I know they're all famous,
+but I don't know them by name.
+
+-   Gregory Marler: England, UK @gregorymarler
+-   Bernelle Verster: South-Africa (@indiebio on most social media)
+-   Christine Karch: Germany (State of the Map chair)
+

--- a/sessions/qa/AZPHEF.md
+++ b/sessions/qa/AZPHEF.md
@@ -1,0 +1,89 @@
+---
+layout: qa
+title: "Lightning Talks I"
+code: "AZPHEF"
+---
+
+**Note: these short talks won't have a live Q&A section.** You are
+welcome to write questions below which the speakers may answer here, or
+ask them in the social channels.
+
+Please also add relevant URLs here.
+
+**Kenya Covid-19 Tracker**
+
+1.  Were there any issues in accessing government data?
+
+
+**Mapping Gender issues in Kenya**
+
+1.   Are you aware of MakeoverMonday for visualising gender issues?
+    1.  (example here
+        <https://opfistula.org/an-update-on-our-work-to-visualize-gender-equality/)>
+2.  Is the data you collect all Open Data?
+3.  How about transgender issues too?
+4.  Congratulations for the talk!
+
+
+**Where can you dine like a king?**
+1. Are there weblinks?
+
+1.  1.  Map of hand-picked restaurants inside or nearby castles of
+        Switzerland:
+        <https://umap.openstreetmap.de/de/map/burg-und-schloss-restaurants-der-schweiz_4106>
+    2.  White paper: <https://md.coredump.ch/s/H1IQbLzjU#>
+    3.  Slides (extended version):
+        <https://www.slideshare.net/StefanKeller/where-can-you-dine-like-a-king>
+    4.  Source code of OSM Data Sync QGIS plugin (WIP):
+        <https://gitlab.com/Chilfing/OSMDataSync>
+    5.  QGIS:  <https://qgis.org/en/site/>
+
+2\. Q. Do you see possibilities of using it to improve data review?
+
+1.  1.  A. For data review I recommend another plugin which inspired
+        this plugin, called Go2NextFeature3. Go2NextFeature3 is
+        available as regular plugin. We've enhanced this plugin to
+        Go2NextFeature3+ and this is another white paper about data
+        validation:  <https://md.coredump.ch/s/rk9r2k69Q#>
+
+
+**Nurturing a Ministry of Mapping**
+Website: <https://www.ministryofmapping.com/>
+1. Sounds like there are some big conflicts under the hood... deletion
+wars? I hope not! - mapmakerdavid
+2. A community of care-tographers! LAVET! - \#mapagmahal hihi
+
+**Building the Street View Experience, Lagos, Nigeria**
+1. Uh oh: "Google's "Street View" is a Registered Trademark...."
+
+1.  1.  Thanks for the correction. We will adjust accordingly
+
+
+**What”s new on OSMCha?**
+
+**GeoLadies PH**
+fb.com/GeoladiesPh
+<https://geoladiesph.github.io/home/>
+
+1. Hope there is also transgender (lgbT) representation.
+
+1.  1.  There is a MapBeks mapping community in the Philippines too,
+        which advocate for LGBTQ+ mapping initiatives. GeoLadies PH also
+        supports MapBeks' projects.
+    2.  check out mapbeks' talk tomorrow at 10:00 UTC! :)
+    3.  Geoladies and Mapbeks are closely working together to represent
+        the underrepresented &lt;3 (MapBeks)
+
+
+**Fighting FGM (Female Genital Mutilation) with Maps**
+1. Hope they round up the bad guys.
+
+1.  1.  Yes, the police have been arresting cutters.  And we are also
+        trying to reeducate the
+        <https://hopeforgirlsandwomen.com/re-educating-cutters/>
+
+
+(
+<https://wiki.openstreetmap.org/wiki/State_of_the_Map_2020/registration_lightning_talks>
+ has more links .)
+

--- a/sessions/qa/BUYCSC.md
+++ b/sessions/qa/BUYCSC.md
@@ -1,0 +1,82 @@
+---
+layout: qa
+title: "Analyzing the localness of OSM data"
+code: "BUYCSC"
+---
+
+**DOI**: <https://doi.org/10.5281/zenodo.3923062>
+**OSM Science Mailing list**:
+<https://lists.openstreetmap.org/listinfo/science>
+
+**Questions**
+
+1.  \[Done\] Is the local tags analysis, done at the country level or
+    what is the size of "regions" considered? -clairedelune
+2.  \[Done\] Am I "local" when I map gas pipeline  i.e. 1/4 of France?
+3.  \[Done\] It would be great to have access to data about localness -
+    are you planning to release either the data, or your algorithms so
+    that others can run them too? -- Frederik
+
+
+**Comments**
+
+1.  works for me+2. Thanks for letting us know. Many thanks video
+    team!+2 :)
+2.  Pascal Neis , Where did you contribute?:
+    <https://neis-one.org/2011/08/yosmhm/>
+3.  For mappers who start through HOTOSM their first change may be
+    non-local, but you could look for \#missingmaps (or \#hotosm and
+    other tasking manager tags) etc in the changeset comment to filter
+    those out +2
+    1.  I'd say that a great deal of mapping in the developing world is
+        performed by mappers who are starting to map VERY far away from
+        where they live. I'm a great example - that's exactly how I
+        started. -Greg\_Rose
+4.  I agree.  If you live in a well mapped place like London, you may
+    not see any point in adding to OSM there, but when you travel to a
+    relatively unmapped place you are much more likely to map
+5.  Could we find a way to appreciate 'localness' as the best kind of
+    collaboration between 'remote' and 'local' mappers that produces the
+    best map that is usable to the local community for their use and
+    practice (development | humanitarian etc). We are all local on Earth
+    and what we do with our map/database is what counts. - Anni -
+    rosymaps +1
+6.  As a local mapper, I'm paranoid one day someone/something will come
+    along and delete all my hard work! All mappe
+7.  Government boundries don't really match "effective" boundaries, but
+    they are "official", so there is not much we can do. (Usually wrong
+    50 meters.)
+8.  In Taiwan some "hothead" "restored" all the arboriginal names, that
+    nobody who lives there ever heard of. Gee thanks.
+    1.  ---could we focus on developing skills for 'local' validators to
+        reduce this from happening?
+9.  Where are you going to do any case studies?  If you are interested
+    in doing anything in Tanzania we at Crowd2map would be very
+    interested in being involved!  Janet
+10. Perhaps there are three categories: local, visitor, and remote (so
+    'visitor' is mapping on the ground but doesn't have deep local
+    knowledge)
+11. I view my local area to be five km around my home.  Otherwise I
+    would probably have to go to the area to get on the ground
+    information.
+12. Having worked with mappers from Lesotho, I can an amount of local
+    knowledge by proxy, as they can explain what I am seeing from the
+    satilite view. Tad
+13. Yes it is true, mapping in an air-conditioned office works better
+    than in the field with lightning strikes and wars, etc.
+14. Don't tell anybody, but I even mapped all the electric meters. Their
+    serial numbers are great location checks in a rural area. Of course
+    the rendering snobs don't think so.
+    1.  (They're also great for orienteering permanent check in markers
+        :) - indiebio)
+        1.  (I had to call them "street cabinets" Don't tell anyone.)
+            1.  Great name! Seriously, is it a problem to map these
+                (newb question)
+                1.  It's because the city slicker tag committee thinks
+                    they are like ants, not worth mapping.
+                    1.  I think (especially) in developing countries
+                        they are valuable as a location tool, and they
+                        are valuable for recreational purposes like
+                        orienteering (We don't have many forests in SA
+                        so we make a plan for urban events)
+

--- a/sessions/qa/C9NGG3.md
+++ b/sessions/qa/C9NGG3.md
@@ -1,0 +1,52 @@
+---
+layout: qa
+title: "OSM Deep Facts in Developing Country: Indonesia case study"
+code: "C9NGG3"
+---
+**<span class="underline">,,Questions for OSM Deep Facts in Developing
+Country: Indonesia case study</span>**
+Dwi Fanny Wulandari
+
+**Questions**
+
+
+1.  \[DONE\] Have you analyze the gender of your survey respondents?
+    Like how many female and male mapper that active in Indonesia?
+    1.  gender is not included in this study
+    2.  (Don't forget transgender.)
+    3.  OSM users dont' indicate gender in their profile signup
+2.  \[DONE\] Do you have any information about what are the platform
+    that they use for mapping? JOSM, ID, or Mobile that they use the
+    most?
+    1.  she does not ask about the platform.
+    2.  she asked about motivation, mapping (sat, internet, software in
+        areas, or internet access methods)
+3.  \[DONE\] Do you have over time data analysis as well? For example,
+    if someone started in OSM via Grab, HOT etc, do they stay
+    contributing after they leave one of those projects? - heather +1
+    1.  this might be good data to get in the next stages
+    2.  It would be great for you to write up the methodology on how
+        others might be able to analyze the community health and growth
+        in their countries? maybe an OSM diary - heather
+4.  \[DONE\] What do you think motivates people to continue as
+    contributor in OSM? -heather
+5.  \[DONE\] What do you think is the impact of the "one map policy" in
+    the work of OSM in the Indonesia archipelago?
+6.  \[DONE\] What is the next stage for the project?
+
+
+**Comments**
+
+
+-   really great to see a mix of quantitative and qualitative analysis
+    using OSM tools and connecting communities  - heather
+-   it would be nice to see all comunities doing this
+-   This methodology is fantastic and can be built upon. Thanks to
+    Pascal Neis for being an ally to help. the research also reminds me
+    of Martin Dittus' work on HOT community. We do need to work with the
+    CHAOSS community as they have set up research on community
+    engagement and how to show the health. - recommend that Dwi reach
+    out to them  - heather
+    -   <http://martindittus.info/>
+    -   <https://chaoss.community/>
+

--- a/sessions/qa/CDES3T.md
+++ b/sessions/qa/CDES3T.md
@@ -1,0 +1,40 @@
+---
+layout: qa
+title: "The use of OpenStreetMap within the Italian Alpine Club"
+code: "CDES3T"
+---
+<span class="underline">Preguntas para el uso de OpenStreetMap en el
+Alpine Club italiano</span>
+No dude en comenzar a escribir preguntas antes del final de la charla y
+recuerde cambiar el nombre :)
+
+Ponente: Luca Delucchi (
+<https://wiki.openstreetmap.org/wiki/User:Lucadelu> )
+Presidente: Lorenzo Stucchi (@LorenzoStucchi)
+
+Please keep a copy of the previous language before translating to
+another language.
+
+Q preguntas :
+
+1.  \[DONE\] Routing for hikers - Is there dedicated router for hikers
+    in Italy, or elsewhere? Are there recommended tags to help hiking
+    routing compared to normal routing -- chippy?
+2.  \[DONE\] Does relation type=route are ~periodically broken?
+    1.  how do you detect broken routes?
+3.  \[DONE\] Isn't it dangerous for hikers when there are hiking paths
+    that are incomplete or wrong or even not updated in specific areas?
+    How do you deal with this?
+4.  \[DONE\] Maybe it was already said during the talk, do you have any
+    idea how many mappers are mapping for this project?
+5.  Are you using GPS with RTK to better map path in moutains?
+    1.  Path are difficult to map in forests and GPS isn't very accurate
+        ;)
+
+6\. \[DONE\] Are other hiking clubs in Italy interested in this great
+work? --chippy
+
+Comments:
+
+1.  Thank you for the work and this interesting talk.+1
+

--- a/sessions/qa/CKYTVS.md
+++ b/sessions/qa/CKYTVS.md
@@ -1,0 +1,86 @@
+---
+layout: qa
+title: "Send me a Postcard"
+code: "CKYTVS"
+---
+
+1.  You have sent postcards to mappers, but have you ever got one
+    yourself? - Gregory
+2.  Sending postcards too far can be costly, will there be a future
+    feature to only get addresses in your country/region? - Gregory
+    1.  There could be postcard printing services distributed all over
+        the world which will print on demand and from remote senders
+        (for Swiss residents there's e.g. PostCard Creator App)? --
+        Stefan
+3.  You talked about sending postcards because not everyone can afford
+    to travel to SotM. Have you encouraged any of those people to apply
+    for a SotM scholarship? - Gregory. (I will end my questions now, but
+    thank you Ilya for your passion and the human connection shown in
+    this).
+
+
+Notes:
+
+1.  Note many rural people's mailboxes, if any, are far from their
+    houses, so any **<span class="underline">postcards</span>** will
+    get 1. stolen, 2. soaked with rain, etc. before people might get
+    them. That is (one reason) why many people are reluctant to give out
+    their legal address. Furthermore, if a mail arrives, it will cause
+    the whole village to make a big effort to finally get the mail to
+    the person, causing big embarrassment. Also headaches for the
+    postman who doesn't know how to get the mail to the person. (And...
+    postcards might spread virus?!)
+2.  On changesets: It's not easy to comment on changeset from people I
+    know personal. How much harder is it to address new people... +1
+3.  Yes, I'm constantly worried: I thought I mapped that already. Did
+    someone delete it? (Yes there are tools to check.)
+4.  For postcard to black\_bike: Harald Schwarz, Germany, 40880
+    Ratingen, Weimarer Straße 1      :-)
+5.  Just in registering progress at osmcards.org  !!! Done. Waiting for
+    cards. And addresses.
+6.  Privacy
+    1.  +1 one answering that already -Enock
+
+
+Comments
+
+1.  Lovely presentation -Enock +1
+2.  Problem of  OSM: Our community lacks club culture of sports clubs or
+    choirs that meet on a regular personal base to train and have fun
+    each week together.
+3.  And mother will see the postcard: Johnny: I told you not to play
+    that "OSM video game" with your friends any more, and get back to
+    your school books. Slap! (Privacy issue. She will open an envelope
+    too.)
+4.  Drinking beer together calms many angry conflicts, lets see if
+    postcards work.
+5.  Sorry but your postcards aren't helping global warming.
+    1.  Warming hearts counts more than minimal climate effect of some
+        postcards.
+        1.  If the sea rises, then there are less places on land that we
+            have to map. :(
+            1.  Coast lines are comlex to handle, so even more global
+                warming,---
+        2.  How about an old fasioned email instead. They can even print
+            it out on a printer if they want.
+    2.  I think the key thing is that this is optional. If you want to
+        minimise postcards being sent, then don't sign up. - Gregory.
+    3.  Some people do not travel to SotM if it means they have to fly,
+        this is a lower-impact way for them to still feel connected to
+        the conference. Not everyone will get that feeling or care for
+        postcards, but that's okay.
+6.  I think this actually could also involve OSM - when the design of
+    the postcard is an OSM based map! So: Did you think about a
+    **postcard printing service** at least to save it as PDF
+    (<https://wiki.openstreetmap.org/wiki/OSM_on_Paper)?> (Stefan
+    Keller)
+7.  Can you explain again on how to use this part of www.osmcards.org?
+    "Use this URL for sharing your profile": ....    
+    <https://www.osmcards.org/profile/>...
+8.  Integrate this as predefined in the OSM Wiki, OSM.org user name?
+    1.  I don't know if Ilya knew how that would be used, you could link
+        to it from your profile page or you could share it by private
+        message if you want.
+    2.  See an example here: <https://www.openstreetmap.org/user/Zverik>
+        :) -- Ilya
+

--- a/sessions/qa/DVR7ME.md
+++ b/sessions/qa/DVR7ME.md
@@ -1,0 +1,24 @@
+---
+layout: qa
+title: "Building Stronger Communities Together - the Local Chapters & Community Working Group"
+code: "DVR7ME"
+---
+
+LCCWG page:
+<https://wiki.osmfoundation.org/wiki/Local_Chapters_and_Communities_Working_Group>
+
+Link to the Local Chapters Congress Form:
+<https://docs.google.com/forms/d/1ZgqIESndEh-J5HB7zk6E_Sq1KuJefaxm6rM3o3s_odc/edit>
+
+Microcosms demo instance:
+<https://microcosms.apis.dev.openstreetmap.org>
+
+
+1.  Can someone touch on the benefits and issues with having a
+    globalized welcoming standard to these local chapters (differnet
+    cultures, systems and such may benefit for variability, but
+    seamlessness might be good).
+2.  Microcoms is really a nice idea :)
+    1.  but did you heard about Mobilizon ? <https://test.mobilizon.org>
+    2.  this beta is really functionnal ;)
+

--- a/sessions/qa/DYXWDC.md
+++ b/sessions/qa/DYXWDC.md
@@ -1,0 +1,223 @@
+---
+layout: qa
+title: "There might have been a misunderstanding..."
+code: "DYXWDC"
+---
+
+-   Please sign your comments
+
+
+**Questions**
+
+
+1.  How to explain it to 6 million users? OpenStreetMAP is not a map and
+    the website where you see a map can not be used as any normal map.
+    +1 (Only 6 million? Viewers too?)
+    1.  How to keep them interested and excited to contribute more
+        without a good and functional website?
+2.  \[DONE\] How about Allan Mustard's views. And debate between you and
+    him?
+    1.  (note - I would love for a true debate on the versions of OSM
+        the project and community. And, if we could add some
+        voices/opinions from Asia, Africa, or South America, that would
+        be great too.)
+3.  The data seems outside of the point. Google Maps is a product, with
+    definite end users identified and goals. We don't even have a
+    consistent understanding of the users for the website. Isn't that
+    what confuses people about OSM? How can we better communicate what
+    OSM is about?
+4.  \[DONE\] How much of your talk is OSM policy vs your personal
+    opinion? +3
+5.  \[DONE\] Has anyone ever seriously argued that OSM should include
+    promotional blurb for businesses, like the dentist example you gave?
+    1.  Answer (in Q&A session; paraphrased) "No, but I have deleted
+        many"
+    2.  \[DONE\] Why couldn't OSM also be a "business directory"?
+        1.  users need to know where is the dentist, the grocery… when
+            it is opened…
+        2.  See the the success of Ça Reste Ouvert during the COVID-19
+            crisis
+        3.  Admit it, phone number tags mean you are more than just a
+            map. (Good thing too.)
+6.  \[DONE\] Why is there an 'us' and 'them' approach in how people use
+    OSM? Whether is it is civic tech or humanitarian, surely there is
+    just 'human' engagement with the project?
+    1.  lol -- I think this question was referring to Frederik's
+        perspective
+7.  \[DONE\] Should the OSMF being working with press to counter-act
+    these misconceptions or at least attempt to have as much press
+    coverage as HOT? (+2)
+8.  \[DONE\] Couldn't OSM as a whole attract just as much or more
+    funding as the humanitarian groups do, except that OSMF has not
+    wanted this funding?
+9.  \[DONE\] Have you ever visited a mapping community in Africa? South
+    America? Asia? +2-1
+10. Why does this view of OSM - the project and the community not take
+    into account the different approaches and contexts of local
+    /regional mapping?
+11. Hey wait a second. Who gets to say what OSM "is" and "isn't" any why
+    define it "so fast" in the first place?
+12. OK, you've got great ideas. But are you ever changed any since you
+    joined OSM ever or are they the same from day 1?? ?
+13. \[DONE\] Why did you go against the on the ground rule in Crimea?
+    +2-1
+14. Can you give a single example of an AI mapping proponent who has
+    said that the community inputs are not important? Just one please.
+    1.  <http://mike.teczno.com/notes/openstreetmap-at-a-crossroads.html> -
+        "Left to the craft wing, OSM will slide into weekend irrelevance
+        within 5-10 years" There you go.
+        1.  +1-1
+        2.  eh -- don't see the equivalence in those statements
+            1.  (+1)
+        3.  This statement clearly indicates that the “craft wing” is a
+            sub-set of the community at large, so it’s not a good
+            example of an AI mapping proponent saying that community
+            inputs are not important.
+            1.  "&lt;group&gt; will doom OSM" = "these people are
+                unimportant" c'mon!
+                1.  "&lt;group&gt; will doom OSM" is a misqoute; the
+                    true quote is "&lt;group&gt; would doom OSM if
+                    &lt;circumstace&gt; applied" - it was an arguement
+                    against &lt;circumstace&gt;, not &lt;group&gt;
+                    1.  "If we only have &lt;group&gt; things will get
+                        really bad" = "&lt;group&gt; is not important"
+                        1.  No, it is not; it is &lt;group B&gt; is also
+                            requried"; consider: "if you only consume
+                            water, you will die"
+    2.  Facebook's first attempt of AI/CV import was done without
+        telling anyone <https://news.ycombinator.com/item?id=17856687>
+        1.  4 years ago....
+        2.  The question didn't have a time limit ;)
+            1.  +2
+            2.  Clever way to get around answering the real question
+                1.  The question had explicit "just one" request
+                    1.  Which you have failed to provide.
+                        1.  This is like arguing with a biblical
+                            fundamentalist about contradictions in the
+                            bible! You can twist anything into anything.
+                            :)
+                            1.  I invoke *Arkell v. Pressdram*
+                        2.  Let's reset: Is there evidence that the
+                            proponents of AI based mapping are not
+                            supportive of community mapping at present?
+                            1.  The evidence has been provided. Are you
+                                really trying to have a good faith,
+                                genuine conversation? ;)
+                                1.  No evdinece has been given, that
+                                    satisfies the request "Can you give
+                                    a single example of an AI mapping
+                                    proponent who has said that the
+                                    community inputs are not
+                                    important?". HTH.
+                            2.  Yes. Are there current examples. Not 4
+                                year old ones
+                                1.  That's a different question
+                            3.  ↑ stop. This is a silly thread.
+                                1.  I like levels
+                                    1.  Me too
+                                        1.  But this is getting
+                                            1.  silly
+                                2.  this guy needs to understand make
+                                    research on how HOT has been very
+                                    good to communities, African
+                                    communities have grown cause of
+                                    support from HOT
+                                3.  I don't think he only references
+                                    HOT. you are conflating
+                                4.  how much research does Fredrick do??
+
+
+Frederick can usually be found on IRC and is hosting a BBB "Virtual Pub
+Meet" session tomorrow, you could chat to him there. We can also look
+forward to him perha
+
+
+**Comments**
+
+
+1.  "openstreetmap.org is not aimed at the public (but at mappers)" Well
+    the public can see it more and more all over the place... For every
+    1 mappers that see it, there are 100regular people who see it when
+    looking at e.g., government websites that have chosen it as their
+    background.
+2.  As I know:   instead of "we are not a map (but a database)"  We are
+    an ecosystem ( community of mappers + database + developers +
+    companies + AI algorithms )  .. in this priority orders ..  imho: 
+    We need New Values !   and need a **New OSM Manifesto** !
+    1.  +1
+3.  "why the OSM community is often skeptical about filling an empty map
+    with data imports, about AI contributions, or about automatic
+    edits" - parts of the OSM community; please don't presume to speak
+    for me.
+4.  Sure, OSM on its own is NOT a "competitor of Google Maps"... and you
+    outline the points clearly as to why it's not. However, OSM is a
+    major and necessary part of (or perhaps powering?) a larger
+    ecosystem of tools/data/products that together are a
+    substitute/competitor/superior product to Google Maps for certain
+    regions of the world and certainly for specific purposes (i.e.
+    humanitarian applications or routing (in some areas)).
+5.  There's no reason we can not show more than "control" of borders.
+    It's just a tagging problem.
+6.  Alas, local hothead OSM leaders define what is on the ground
+    (language of place names in Taiwan).
+7.  HOT does a lot of good work to train people on the ground so that
+    they can make and maintain their own maps; the comments made in this
+    presentation seem to be a gross misrepersenattion +1
+    1.  Reply: yes, but not everyone working in humanitarian mapping
+        does this, and it's a newer phenomenon for many. It's a fair
+        point.
+        1.  That wasn't the point the speaker made; he mis-described HOT
+            as a whole, single, entity +1-1
+            1.  Is HOT not a single entity?
+                1.  not according to "not everyone working in
+                    humanitarian mapping does this"
+                2.  Everyone working in humanitarian mapping is not a
+                    part of HOT...
+                    1.  the original point - which you said was "fair" -
+                        was about HOT.
+                        1.   Oh by the speaker? I did not hear him speak
+                            only re: HOT but outside of that it is a
+                            fair point...As well even HOT has made a lot
+                            of changes over the years.
+                    2.  +1
+8.  Pretty dismissive attitude towards humanitarian mapping. "Rich
+    college kids"
+    1.  +2
+    2.  -1 (it was an example, don't have to take everything
+        literally..imo)
+        1.  1.  It was stated literally. but as an exampe, it would have
+                been a dismissibve one.
+    3.  +1-1
+    4.  Yes very partronising  Rich countries giving maps to poorer
+        ones??? +1-1
+    5.  So you don't think that rich college kids do a lot of
+        humanitarian mapping?
+    6.  \#NotAllHumanitarianMappers: srsly? 🙄
+9.  Fairly colonialist approach and tone about 'for africa rather than
+    with 'communities'
+    1.  I don't think that is what the speaker said, he was critiquing
+        that approach. Or did I mis hear?
+    2.  I don't think the speaker has a good idea of how HOT works and
+        how OSM works outside of Germany
+10.  The terms "ground" and "field" are often considered limiting in
+    terms of power and equality.
+11. Frederik’s “straw man voice” (the vocal inflection he uses when
+    putting word in other people’s mouths) is a very ineffective
+    rhetorical choice. I’m having trouble tracking which things are his
+    opinions and which things are the opinions he ascribes to others.
+12. There is no one way to OSM - there are many. The tone about
+    'humanitarian mapping' and/or 'mapping in africa' misses that the
+    way that people engage in the project and the community is diverse -
+    thus a global community. The filter used here should not be
+    considered "FACT" but a version. I hope that people can give space
+    for other versions more.
+    1.  "You are entitled to your own opinions - but not your own facts"
+13. Yes, ever since Google started charging, lots of websites switched
+    to OSM: Thus indeed a competetor to Google maps. -jidanni
+14. Allan is not new to OSM. He has done his research.
+    1.  +1
+    2.  +1
+15. we can map a path on a private backyard that we can not see from
+    outside, but we can not map a shop without an outside sign?
+16. Nice to catch the habit. Inclusive language is important. :-)
+

--- a/sessions/qa/DZ8PWQ.md
+++ b/sessions/qa/DZ8PWQ.md
@@ -1,0 +1,54 @@
+---
+layout: qa
+title: "Building mapping communities in rural Tanzania – challenges, successes and lessons learnt"
+code: "DZ8PWQ"
+---
+
+Add questions here:
+
+1.  (Due to technical issues with my hardware I am filing this even
+    before I attended the session) What happens when oral or local
+    tradition differs from a national naming convention or even
+    databases or when different languages collide in spelling or even
+    the whole name? For example, we know from India, that spelling of
+    geographic names differs between Hindi und Bengali, which is
+    resolved by the India Geographical Survey by standardizing
+    geographic names only in English language. And, does the collecting
+    of names by mobile on the field lead into a later process of finding
+    standard names in official GIS systems? Thank you, Matthias (German
+    Wikipedia user Matthiasb).
+2.  Very useful project, Janet and well done! What do you think are the
+    importance of the map to the community? Is it about using it to
+    lobby for development or for visibiliity to the world and for
+    potential investments in the area? It seems to me that, in terms of
+    map usage, the villagers probably know where everything is located
+    but perhaps not outsiders. Thanks for showing the video showing
+    reasons why they need maps! Great work! My questions are answered by
+    the video and many thanks!
+3.  What an incredible project!! Amazing work and thank you for sharing
+    :) Especially love the emphasis on the lives of girls and that you
+    are highlighting the challenges of equipment and access to wifi even
+    in the local universities. Already on your website and looking
+    forward to learning more about and from your project. Anni (Mansueto
+    Institute at the University of Chicago)
+4.  Very inspirational! Does your group use Tasking Manager for setting
+    up mapping tasks and projects?
+    1.  <https://tasks.hotosm.org/explore?organisation=Tanzania%20Development%20Trust>
+5.  Do you welcome remote mappers from other areas to help with your
+    projects? -Greg\_Rose
+    1.  Yes, absolutely!
+
+
+The video restart in track 1 ? :)
+
+-   This was a different lightning talk happening at the same time :)
+
+
+The video at the point it dropped is here
+<https://youtu.be/wdl1WA_GvAU?t=1168>
+And from the begining is here <https://youtu.be/wdl1WA_GvAU>
+And for our Slack Channel
+<https://join.slack.com/t/crowd2map/shared_invite/zt-dhhcwlkg-ROTlhoST1Rsz9Edhm67hsw>
+
+ <https://tasks.hotosm.org/explore?organisation=Tanzania%20Development%20Trust>
+

--- a/sessions/qa/EYDKX3.md
+++ b/sessions/qa/EYDKX3.md
@@ -1,0 +1,64 @@
+---
+layout: qa
+title: "Detecting informal settlements via topological analysis"
+code: "EYDKX3"
+---
+**<span class="underline">Detecting informal settlements via topological
+analysis</span>**
+Abstract in the proceedings of the SotM 2020 Academic Track:
+<https://zenodo.org/record/3928690>
+Full proceedings of the SotM 2020 Academic Track:
+<https://zenodo.org/communities/sotm-2020>
+
+**Questions**
+
+1.  \[ANSWERED\] Can you comment on informal settlements detected in
+    South Africa? asseblief \[please\] ;-) -- Serena. Thanks, we are
+    mapping away, but it may take some time...
+    1.  (comment:
+        [https://www.openstreetmap.org/\#map=17/-34.06021/18.66231,https://millionneighborhoods.org/\#17/-34.06021/18.66231](https://www.openstreetmap.org/#map=17/-34.06021/18.66231,https://millionneighborhoods.org/#17/-34.06021/18.66231) 
+        -- YaguraStation)
+2.  \[ANSWERED\] Maybe off-topic, regarding above example in 1.
+    (Monwabisi Park): City planning-wise how would their situation be
+    improved(eg. in regard to accessibility)?
+3.  \[ANSWERED\] You discussed reblocking, and in your paper you show
+    how "We observe that new infrastructure segments typically appear as
+    dead-end streets (culs-de-sac), as the minimal edge set needed to
+    connect a collection of nodes will always yield a tree graph." But a
+    street network of dead-end streets is notoriously harmful to
+    walkability (as in USA suburbs), and will result in residents having
+    to take long network-distance walks when the absolute distance of
+    their trip is short. How can you help ensure this will not be used
+    to design neighborhoods that are difficult to walk in? Thanks for
+    your fascinating talk! -Taylor, ITDP (thanks for reading the long
+    question!)
+    1.  Marco: you are welcome, thanks for the interest!
+4.  \[ANSWERED\] Is it possible to assess/compare the quality of the
+    settlements with the OSM boundaries?
+5.  \[ANSWERED\] What are the software tools you used to perform the
+    work/run the model? Is the source code available? -- Marco Minghini
+
+
+**Comments**
+
+1.  \[ANSWERED\] If those "cadastral maps" ever leaked to the commumity
+    they would go nuts: "Hey that's my land. You gave it to neighbor C",
+    etc.-jidanni
+    1.  Even real cadastral maps are sensitive. (usually due to not
+        being aligned precicsly... even that is source of endless
+        arguments.)-jidanni
+    2.  Even slightly out of date real cadastral maps are destroyed by
+        govenments, to avoid misunderstandings.
+    3.  No matter if there is big warning "not a real cadastral map"...
+        people will take it as the real thing.-jidanni
+2.  Yes I wanted to do a historical cadastral map project... only to
+    find even the parcel numbers had been erased by the Taiwan
+    government due to "sensitivity". (Could only query one by one.)
+3.  All the buildings I trace from imagery are squwed several random
+    meters thanks to Bing, etc. I hope you have better grasp of real
+    WGS84 locations.-jidanni
+
+
+OSM Science Mailing list:
+<https://lists.openstreetmap.org/listinfo/science>
+

--- a/sessions/qa/EYMZXV.md
+++ b/sessions/qa/EYMZXV.md
@@ -1,0 +1,11 @@
+---
+layout: qa
+title: "Overwiew on OpenStreetMap Togo Community"
+code: "EYMZXV"
+---
+
+Add questions here
+
+1.  The project to map pharmacies sounds great, is it ongoing ?
+    1.  Yes, it is an ongoing project
+

--- a/sessions/qa/FLHGVQ.md
+++ b/sessions/qa/FLHGVQ.md
@@ -1,0 +1,66 @@
+---
+layout: qa
+title: "Examining spatial proximity to health care facilities in an informal urban setting"
+code: "FLHGVQ"
+---
+
+Proceedings DOI: <https://doi.org/10.5281/zenodo.3923053>
+
+**Questions**
+
+1.  \[DONE\] Did you consider the topography? at our slums
+    (e.g.Salvador, Rio - Brasil) paths can be reeeealy steep and
+    considerably change distance time and route decision. (Great work
+    showing how important it is to consider the route distance)
+2.  \[DONE\] what challenges regarding security for mappers did you
+    encounter? how did address them?
+3.  \[DONE\] You mentioned careful training of mapping tools is very
+    important. What are so lessons learned/best practices for how to go
+    about this training?
+4.  \[DONE\] You mentioned collecting data for streets and footpaths to
+    be able to calculate network distance. Did you find that your data
+    collection significantly improved OSM's coverage of the footpath
+    network, or was the existing data already of reasonable quality?
+5.  \[DONE\] Was the size of the health service a factor, for example
+    the amount of Doctors/nurses for the amount of people in the
+    vicinity.
+6.  \[DONE\] Did you encounter spatial heterogeneities regarding
+    possible drivers like socio-demographics/economics (which may be
+    fairly unknown within informal settlements; you mentioned taking
+    these into account in your outlook)? Maybe you have found at least
+    visual clues to such potential relations by just mapping your
+    results as a first step? - René
+
+
+**Comments**
+
+1.  Love love love the work of this group!! Looking forward to the
+    presentation! Anni - rosymaps (chicago).
+    1.  Many thanks, Rosymaps! - Godwin.
+2.  amazing slides - diagrams were really helpful
+    1.  Thank you!
+3.  this kind of study here is showing serious problems of individual
+    transportation for people susppected with COVID-19
+    1.  I agree!
+4.  The slides are great!
+    1.  Thank you!
+5.  Thanks for sharing, great presentation - really like the comment
+    about "the right tool for the job" - Cameron Green
+    1.  I agree, it ought to be right. Another thing is to consider how
+        resilient the method is; redundancy can be useful here.
+        1.  Understanding the users of the tools is also important,
+            certain tools come easier to certain users than other tools
+            do. I have been working on a project about this and that was
+            the first thing I learnt.
+            1.  I agree, Cameron. For example, in our online mapping
+                stage, iD editor for mapping was very useful. JOSM was
+                useful during the validation stage.
+                1.  I agree fully, thank you very much for the
+                    presentation.
+
+
+**OSM Science Mailing list**:
+<https://lists.openstreetmap.org/listinfo/science>
+
+Many thansk everyone for the great session and participation!
+

--- a/sessions/qa/FZCM39.md
+++ b/sessions/qa/FZCM39.md
@@ -1,0 +1,42 @@
+---
+layout: qa
+title: "Meet an OpenStreetMapper"
+code: "FZCM39"
+---
+
+1.  (For Ian and Hanna) Is there any question you wished I asked you? -
+    Gregory
+2.  For Hanna, what kind of things are done by the board of directors.
+    In Ireland we have just formed a company and could would like to
+    hear your breakdown between practical work and project planning.
+    1.  Thanks for the answer, is there working groups that take care of
+        some of the practical tasks, or is it done by volunteers and not
+        as defined.
+3.  Koln map: well with so much on the map, I bet there are deletion
+    wars? "Who took my trees off?" "I did. We don't need such junk
+    cluttering the map."
+4.  Koln map: So are all cell towers (secret in some countries) mapped
+    yet?
+    1.  And are they disguised as trees etc?
+5.  So the government might even use OSM as a cadastral map basis? Or I
+    guess they still have their more precise maps.
+
+
+Comments:
+
+-   Room wall echos. Volume levels sometimes dips.
+    -   Yes, sorry I had limited places that I could be undisturbed. I
+        should have gone outside like Ilya. - Gregory.
+
+<!-- -->
+
+-   -   (Use lapel neck mike too.)
+
+<!-- -->
+
+-   Here are the telecommunication towers in Cologne:
+    <https://overpass-turbo.eu/s/VNq>
+    -   OK, but some hide:
+        <http://jidanni.org/geo/openstreetmap/celltowers.html>
+-   So.... eventully goverments will end up using OSM!
+

--- a/sessions/qa/HLFEER.md
+++ b/sessions/qa/HLFEER.md
@@ -1,0 +1,45 @@
+---
+layout: qa
+title: "Visualizing Gender of Street Names in Brazil"
+code: "HLFEER"
+---
+
+1.  You know about <https://equalstreetnames.brussels/> and
+    <https://naziviulica.openstreetmap.rs/> ? \[by black\_bike\]
+2.  Can data from a private API really be open? +1
+    1.  Can it legally be open-sourced? -- Raphael (das-g)
+3.  Are there streets named after persons, but without the given name in
+    the street name (e.g. just the family name)? -- Raphael (das-g)
+4.  How are streets split into multiple ways counted?
+    1.  It seems not number of streets but street lengths were counted,
+        so the splitting shouldn't matter. -- das-g
+    2.  As OpenStreetMap lacks the concept of "street" counting them is
+        the hard part.
+5.  <s>Did you find interesting differences between regions in
+    Brazil?</s>
+6.  For your matching of the names vs streetname, how long did that join
+    take? Any tips on making the join faster? (indexing ect? )(Keith H)
+    Thanks!
+7.  Did you disregard titles completely or also use them to determine
+    gender? One can probably assume, that in catholic regions, all popes
+    are male. -- das-g
+    1.   No, there were some lonly female popes.
+8.  Given names only don't need to be anonymous. They can be dedicated
+    to one person. Needs research.
+9.  Did you assess the quality of this method based on a subset with a
+    source of known genders? (Like name:etymology:wikidata -&gt; sex or
+    gender (P21) or similar)
+
+10\. Is the peripheral link to females related to the streets being more
+recent than the older central streets I wonder?
+
+1.  1.  (Bernardo, since the stream ended): that could be a factor...
+        But it could also be that the more "important names / people"
+        were used for the more central and "more important" streets, and
+        for smaller streets in the periphery there's more openesss to
+        name it after a figure that is not "so historically important".
+        But this is a hunch, needs further research!
+        1.  Interesting - many thanks for an interesting talk. Lots to
+            investigate !
+            1.  You're welcome! Thanks for watching!
+

--- a/sessions/qa/HUKVDK.md
+++ b/sessions/qa/HUKVDK.md
@@ -1,0 +1,85 @@
+---
+layout: qa
+title: "From Historical OpenStreetMap data to customized training samples for geospatial machine learning"
+code: "HUKVDK"
+---
+
+**DOI**: <https://doi.org/10.5281/zenodo.3923040>
+**Github**:  <https://github.com/GIScience/ohsome2label>
+**OSM Science Mailing list**:
+<https://lists.openstreetmap.org/listinfo/science>
+
+
+**Questions**
+
+1.  \[Done\] Does ohsome2label also georeference the results (i.e. land
+    use vectors, building footprint vectors)?
+2.  \[Done\] Question from René: Thanks a lot for your talk! I'm
+    wondering how your approach performs in areas with lower OSM data
+    quality or with sparser coverage. Have you conducted systematic
+    performance tests in corresponding areas? Would be interesting in
+    support of your ongoing work in the Global South, in particular.
+    Yes, it is :)
+3.  \[Done\] How do you ensure the imagery is exactly WGS84 with no skew
+    before you start? Bing: bad, Maxar: often bad.-jidanni
+    1.  Bing is often up to 10 meters offset in rural areas! Basing work
+        on it will really damage the resulting map.
+4.  \[Done\] In some works landuse/landcover information have been
+    derived from geosocial media data, especially from shared photos. Do
+    you see any potential for augmenting your approach taking account
+    also of these data sets (in some areas) especially with regards to
+    possibly achieving fine temporal resolution? \[\]Do you think this
+    could add anything to what you achieve already using OSM data?
+5.  \[Done\] Can you discuss more about your future plans for the OSM
+    quality measurement? Would be interesting to know!
+    1.  Oh no I think it's kind of choppy, I wasn't able to hear.
+    2.  I'll just discuss through email later, thanks! Thank you too for
+        your participation!
+6.  Can you compare your work and the work of Development Seed with
+    Label maker? I'm curious to know the similarities and differences.
+
+
+Answer:
+
+1.  Yes, the result is in slippy map tile format.
+2.  It's two question, for sparse coverage area, it works well since
+    ohsome API offers a roboust feature query function. For the lower
+    quality  area, some more post processing should be done for your
+    training dataset.
+3.  We support customed tms, you can change the bad image with the
+    corresponding image.
+4.  The geosocial media data is varies in different application, so it's
+    hard to handle it in a unified form. But I will think about it, or
+    you can raise an issue on our github page. Thanks! My question was
+    rather exploratory in nature, indeed. Hopefully inspirational though
+    :)
+5.  First, we will try to do some tag-specified intrinsic data
+    indicators, like the quality indicator for the building. Second, our
+    next step is to study how the tile-based osm data quality influence
+    the deep learning training progress.
+6.  For the Label maker, if you have used it before. You will find it's
+    hard to setup. For ohsome2label, you only need to type \`pip install
+    ohsome2label\` then you can get it. The second difference is that we
+    support some data quality analysis for your area of interest, and we
+    will extend this function further. Third, we use MS coco format
+    output and Label marker use npz. Fourth, we have the intermidiate
+    output, so you can modified what you want, like add some feature to
+    your geojson. Ah, we also support overpass api aside Ohsome API.
+
+
+Thank you for your great question. You can connect us by email or on our
+github page any time. It's our pleasure. My email is
+zhaoyan\_wu@whu.edu.cn. Many thanks for taking time to address the
+questions; you were excellent!Thank you!
+
+**Comments**
+
+1.  Award winning session chair. Thanks+1. Many thanks! :)+1 Should say
+    "I'm XX, talking to you from YY (country)".
+2.  audio on video is over blown.+1
+    1.  Noted and thanks, video team will have a look.
+        1.  (Might be a problem of the recording / microphone rather
+            than the stream.)+1
+        2.  (had to turn down the audio source as it was too loud
+            complared to live source.)
+

--- a/sessions/qa/JAG7JD.md
+++ b/sessions/qa/JAG7JD.md
@@ -1,0 +1,34 @@
+---
+layout: qa
+title: "Turkish Law on National Geospatial Data and Its Implications Regarding OSM and the Community"
+code: "JAG7JD"
+---
+
+**Add questions here**
+
+
+1.  What is the reason for the law --- is it connected with resisting
+    Kurdish separatism (by taking control of mapped boundaries)?
+2.  Do you think the government will try to exercise any control over
+    non-Turkish contributors to OSM map data within Turkey?
+3.  \[Anyone\] What are the best English-language sources (press,
+    academic, etc.) to read about this?
+4.  How can those of us outside Turkey support you?
+
+
+**Comments**
+
+
+1.  I had no idea about this - my symapthies to our Turkish colleagues
+
+
+**Links**
+
+
+-   <http://kutt.it/G51j5s> -
+    <https://webdosya.csb.gov.tr/db/cbs/icerikler/geoportal-080818-20180813072536.mp4>
+-   <http://kutt.it/YvzfjP> -
+    <https://tucbs-public-api.csb.gov.tr/cografiveriservishavuzu#osds>
+    -   I cannot access these links..
+        -   They're working
+

--- a/sessions/qa/JDNTHK.md
+++ b/sessions/qa/JDNTHK.md
@@ -1,0 +1,57 @@
+---
+layout: qa
+title: "Minutely Extracts: Tools for nimble editing and downloading"
+code: "JDNTHK"
+---
+
+Hello Mappers :) This is Brandon, the presenter. I'm looking forward to
+your questions!
+GitHub Repo: <http://github.com/protomaps/OSMExpress>
+Documentation: <https://protomaps.com/docs/osmexpress>
+
+**Questions:**
+
+1.  Asking this in advance of the session, so apologies if you answer
+    this: What communities, sectors, or use cases for Minutely Extracts
+    and OSMX have been underutilized so far that you would encourage, in
+    your view? (What are the new limits of ME vs. similar bounds queries
+    in existing tools e.g. Overpass, OSM Extract?) -Thad
+    1.   REPLY: use cases I have in mind are live-updated OSM statistics
+        or vandalism detection; I don't work on these topics though, so
+        hope that developers who do can use these tools. The limit of
+        100m nodes on ME is arbitrary and based on a coarse estimate
+        performed outside osmx; you can exceed this limit if you run the
+        program yourself.
+2.  \[DONE\] Would you be ok sharing the graph simplification tricks?
+    (Already answered on Twitter)
+3.  Do you have books to recommend to a developer with little experience
+    in GIS (but with some general experience and an ok math background).
+    I'd like to learn and be capable of doing the same kind of work as
+    you but don't know where to start
+    1.  REPLY: I have very little GIS background before starting to work
+        with OpenStreetMap! I think there’s lots of opportunities for
+        writing OSM tooling in efficient programming languages like C++,
+        Go, Rust so I would recommend diving into one of those
+4.  Would it be possible to support requesting minute extracts by
+    geographic region, a bit like the geofabrik polygons? Or with an
+    arbitrary Nominatim query? - Guillaume
+    1.  REPLY: Yes, this is something i'm working on, but becomes
+        challenging for relations with thousands of nodes and above
+        1.  Cool, thanks :)
+5.  What do you think are the advantages of Overpass over OSMExpress?
+    1.  REPLY: Overpass has tons of features for interactive querying
+        and also does deep "interpretation" of OSM objects into
+        polygons, etc. osmx does none of that - it's just a file
+6.  I had a break in the internet connection during the talk. Is there a
+    difference compared to the download function of JOSM?
+    1.  REPLY: yes, you can download up to 100 million nodes; however,
+        untagged nodes don't have metadata beyond version number.
+    2.  You can re-watch all the talks at
+        <https://streaming.media.ccc.de/sotm2020/>
+
+
+**Comments:**
+
+
+1.  "MapCook-Bro". Nice.
+

--- a/sessions/qa/JYWQX3.md
+++ b/sessions/qa/JYWQX3.md
@@ -1,0 +1,48 @@
+---
+layout: qa
+title: "Trademarks & OSMF"
+code: "JYWQX3"
+---
+The purpose of the presentation is to provide interested parties with a
+basic explanation of what trademark law is and how the OSMF trademark
+policy works.
+(<https://2020.stateofthemap.org/sessions/JYWQX3/)>
+
+Speech link:
+
+-   Trademark policy:
+    <https://wiki.osmfoundation.org/wiki/Trademark_Policy>
+-   Trademark FAQ:
+    <https://wiki.osmfoundation.org/wiki/Trademark_Policy_FAQ>
+-   Map quickly licensing status:
+    <https://wiki.osmfoundation.org/wiki/SOTM_Quick_Licence>
+-   Project permit and application domain grandfather:
+    <https://wiki.osmfoundation.org/wiki/Project_Licence_and_Domain_Grandfathering_Application>
+
+
+You can contact the OSMF Law/Licensing Working Group at
+trademarks@osmfoundation.org to resolve trademark issues.
+
+You can also find me on Twitter at @kathleenthelaw
+
+Trademark and OSMF issues
+
+1.  You mentioned the need for a license for "www.OSMmirror.com" - to
+    give a well-known example, does this apply to OSMand, and if so,
+    what is the current situation? - Richard F
+    1.  Thank you very much!
+2.  What about visual markers (logos)?
+3.  Do you mean derivatives or real logos?
+    1.  The real logo.
+        1.  In particular, don't confuse visually appealing
+            attributions.
+
+
+<span class="underline">Comments</span>
+
+
+1.  If you have one of these openstreetmap.something domain names and
+    would like the OSMF to transfer it an pay for it, or the OSMF owns
+    it and you'd like to do something with it, please email
+    operations@osmfoundation.org
+

--- a/sessions/qa/KDXFHZ.md
+++ b/sessions/qa/KDXFHZ.md
@@ -1,0 +1,31 @@
+---
+layout: qa
+title: "4 County OSM Digitization Liberia – Lesson Learned"
+code: "KDXFHZ"
+---
+
+1.  Thanks for your talk, do you create some specific JOSM validator
+    rules? or you used the  standard one? I used the standard one in
+    JOSM
+2.  Today I learned that there's specific tags for highways in Africa!
+    just wanted to ask about data validation, how long does it take for
+    a mapper to become a validator? Does it take 1 month? Or maybe less?
+    I guess it depends on how much time they spend on mapping, is it
+    daily, is it every once a week or is it every once in a while
+    1.  yes, thank you! 1 month is not enough got it
+3.  Do you find some difference between the standard tag for highway in
+    Africa and the one in Liberia? No, it's more or less just the same
+    as Africa standard tag on OSM Wiki
+4.  What proportion of Liberia do these 4 counties represent? Are there
+    plans to expand this approach to the rest of the country? If yes -
+    what are the resources needed for that and are they available? If
+    not - is it still valuable to do this exercise for a small fraction
+    of the country? Thank youLiberia has 15 counties, so it's more or
+    less 1/3 of the country has been mapped on OSM and since the Liberia
+    Household Social Registry (LHSR) is done gradually and is projected
+    to cover the entire country in a 2-year period, there's a
+    probability for a similar project in the future
+
+
+Thank you for the presentation Tri
+

--- a/sessions/qa/KNU7L3.md
+++ b/sessions/qa/KNU7L3.md
@@ -1,0 +1,42 @@
+---
+layout: qa
+title: "Earthquakes and OpenStreetMap"
+code: "KNU7L3"
+---
+
+Please feel free to start writing questions before the end of the talk
+and remind to rename yourself :)
+
+Speaker: Danijel Schorlemmer
+Chair: Lorenzo Stucchi (@LorenzoStucchi)
+
+**Questions**
+
+
+1.  \[DONE\] For knowing the risk of the building is to provide the
+    exact location, the level etc of building, what about the road?
+    1.  Could you be more specific please. Do you mean the risk of a
+        road or the just the position of building on the road?
+        1.  I meant the risk of road
+2.  \[DONE\] The example of San Francisco is great but that was thanks
+    to a data import project from Gov open data, what will happen in
+    countries when the Governmemnts don't want to share this data to OSM
+    because there might be corruption on the construction licenses they
+    gave?
+3.  \[DONE\] Does this research need DEM external data?
+4.  \[DONE\] The lack of geological data on OSM and often among the
+    opendata is a limit for the model? Would this type of data improve
+    the model?
+
+
+**Comments**
+
+
+1.  In some "informal" cities, buildings didn't apply for permits and
+    are in fact illegal, so any mapping of them is rather "sensitive."
+2.  Realtors would not be happy to see your maps.
+    1.  Certain classification info (estimations) we are internally
+        calculating on a building level, we don't give them out
+        publicly, but rather just work tightly with local authorities.
+        (Felix, GFZ)
+

--- a/sessions/qa/L3RTUK.md
+++ b/sessions/qa/L3RTUK.md
@@ -1,0 +1,94 @@
+---
+layout: qa
+title: "MAPBEKS: Mapping of HIV Facilities and LGBT spaces in the Philippines on OpenStreetMap"
+code: "L3RTUK"
+---
+
+Speaker: Mikko Tamura
+
+NOT ALL SPACES ARE DEFINED  BY STRAIGHT LINES &lt;3♥♥ +1
+HAPPY PRIDE! STONEWALL WAS A RIOT! BE GAY, DO CRIMES! 🏳️‍🌈🏳️‍🌈🏳️‍🌈
+🏳️‍⚧️🏳️‍⚧️🏳️‍⚧️ ⚢⚢⚢ ⚣⚣⚣ ⚤⚤⚤ ⚥⚥⚥ ⚧️⚧️⚧️ - HAHAHAH Happy Pride &lt;3 -
+-happy pride
+
+ From Mikko
+
+-   "mapping is not a straight line"
+-   "mapping needs to be more accessible"
+-   "mapping should not just be for people who know how to make maps"
+-   "mapping should be for everyone"
+
+
+**Resources:**
+
+
+-   Slides - <https://slides.com/mikkotamura/deck/fullscreen>
+-   LGBTQIA Map - <https://bit.ly/lgbtph>
+-   HIV Facilities Map-<https://bit.ly/hivmapph>
+-   MapBeks Stories - <https://bit.ly/mapbeksstories>
+-   Stories of Bullying and Discrimination - <https://bit.ly/sodb>
+
+
+
+Please LIKE, Follow, Subscribe:
+
+-   Facebook: <https://fb.com/mapbeks>
+-   Twitter: @mapbeks
+-   Instagram: @mapbeks
+-   Youtube: @mapbeks
+-   RAINBOSM Telegram Chat - the most fabulous OSM group chat that
+    exists! <https://t.me/RainbOSM>
+
+
+**Questions:**
+
+
+1.  \[DONE\] Do the things you map(like safe spaces) change, how
+    frequently do you have to check the mapping? - Gregory
+2.  \[DONE\] Are these maps secret somehow as these open maps can lead
+    to vulnerability issues, can't authoroties use them to track down
+    the community members?- Trudy
+    1.  -redacted spaces and adjustments are done for safety of
+        participants - heather  (Mikko's comment)
+3.  \[DONE\] How have you collaborated during the Covid times? What has
+    been the impact? What recommends would you have for other LGBTQI
+    communities around the world, including safe spaces?- Heather
+    1.  \- the map during covid had 20,000 views during covid times - to
+        help people (Mikko's comment) - heather - fantastic work!!
+4.  \[DONE\] What are some ways that the map connect this community?
+    -heather
+    1.  \[Mikko\] There are hundreds of LGBT organizations in the
+        country but they are not connected thus through mapping these
+        spaces we are able to show force/power/existence to other
+        people. Amazingly we (LGBT community) were able to see that even
+        in far-flung areas there are LGBT groups that emerge.
+    2.  We T (of LGBT, Type: "CD") are so few, that we need a map of
+        where we all live. So we can find each other! (Alas, as any
+        precise mapping is quite personal...). (Sure, there are
+        apps...) - I do not suggest that we map per individual house of
+        the location of our sisters and brothers but it is an empowering
+        way already that we. can map the location of support
+        organizations. Ideally, we eventually find. ourselves among the
+        crowd. We need to stand out as a collective so that we can also
+        be there for others. Be a beacon and a sanctuary for others
+        &lt;3 \[MapBeks\] I can help set things up for you but make sure
+        that the safety is always considered.
+    3.  \[Mikko\] Focus on organizations that provide services for
+        LGBTQI  -  we are still collating data and validating locations
+        of health services such HIV facilities and clinics that support
+        our transbrothers and sisters
+
+
+**Comments**
+
+
+1.  Welcome in your nearest neighbor: Taiwan - jidanni -  Hope we can
+    meet!!!!!! &lt;3 \[Mikko\]
+2.  Nice talk. Greetings from France "mapping is not a straight line"
+3.  Remember: There's RainbOSM, <https://t.me/RainbOSM> a Telegram group
+    for LGBTQ people in OSM. (Safe space w/ a CoC obv)
+    1.  +1
+4.  So proud of you and your advocacy, Mikko! Lablab!!! ❣️🏳️‍🌈 - Andi -
+    I LOVE YOU TOO MAMEY!
+5.  Love the hair!
+

--- a/sessions/qa/LDGZ37.md
+++ b/sessions/qa/LDGZ37.md
@@ -1,0 +1,96 @@
+---
+layout: qa
+title: "Participatory Budgeting & Mapping with citizens and government"
+code: "LDGZ37"
+---
+<span class="underline">Questions pour la budgétisation et la
+cartographie participatives avec les citoyens et le
+gouvernement</span>
+
+please feel free to add your name / OSM username and location if you
+want to!
+
+Links to Maps from the talk:
+    <https://mapkibera.github.io/counties/>
+
+
+-   \[ANSWERED\] What other software platforms are used besides OSM?
+-   \[ANSWERED\] ODK Were there any issues with ODK?  And if so how have
+    you overcome them?
+    -   There were issues on how the form is built because it doesn't
+        fit exactly with OSM tags.So we had to fix/make the form in a
+        manner that will match the OSM tags.
+-   Yes would love to know more about grant and what you have done etc..
+    Janet
+    -   So far we're still defining the details but we will be likely
+        enabling a "translation" into "OSM" as a language that could be
+        selected and translated into on export. allowing the CSV to be
+        imported to JOSM for final edits or directly. I can talk to
+        anyone with more details - Erica
+-   \[ANSWERED\] So OSM must be much better than Google in Kenya by now,
+    no? -jidanni/Taiwan
+-   Next step: cadastral mapping! (Yes, there are OSM tags.)
+    -jidanni/Taiwan
+-   \[ANSWERED\] You produce fantastic maps.  How much training did
+    people need to be able to create them? And is there any
+    financial/budget information shown on any maps? I meant to create
+    the maps in QGIS etc, how many people are involved in that?
+    -   Our lead mapper Zack does that, and then I've been using Canvaa
+        online to layout the maps after for print. (Erica)
+-   How many times have you revisited Kibera for mapping over the years
+    to keep the map up to date?
+    -   We've been doing updates on our data just to ensure that the
+        data is up to date since things keep on changing. Updates are
+        usually done like twice or thrice a year. In other cases we do
+        updates when consulted by an organisation to do some mapping for
+        them. When we also have projects we do updates at the same time.
+-   Lucy - you have been working with MapKibera since 2009! From your
+    perspective, how have attitudes to OSM changed in Kenya since then?
+    How have you got buy in with local government?
+    -   i have seen the OSM community grow since the since as Mapkibera
+        we;ve been able to transfer knowlege to different
+        groups/institutions thus have a wider community of contributors
+        on the OSM platfrom. As far as local gov't, we have built
+        relationships with various officials in Nairobi when possible.
+        In this project the World Bank had already created these
+        relationships so we mainly followed their lead, although by
+        getting to know them better we were more successful in some
+        areas than others.
+-   What if donors pull all their funds. Will / can the public continue
+    mapping in a "hobby" fashion? Or are they not excited that much to
+    continue?
+    -   people are concerned to know what facilities they have or rather
+        the distribution of these facilities so i think they will have
+        to continue mapping regardless of wether funding is there ar
+        not.
+
+
+Comment: JOSM, with its different mouse binding (left vs. right) messed
+up my "muscle memory". So I must use iD.
+
+**Ajoutez des questions ici**
+n'hésitez pas à ajouter votre nom / nom d'utilisateur et emplacement OSM
+si vous le souhaitez!
+
+
+-   Quelles autres plateformes logicielles sont utilisées en plus d'OSM?
+    -   ODK
+-   Y a-t-il eu des problèmes avec ODK? Et si oui, comment les avez-vous
+    surmontés?
+-   L'OSM doit donc être bien meilleur que Google au Kenya, non?
+    -jidanni / Taiwan
+-   Prochaine étape: la cartographie cadastrale! (Oui, il existe des
+    balises OSM.) -Jidanni / Taiwan
+-   Vous produisez des cartes fantastiques. De combien de formation les
+    gens avaient-ils besoin pour pouvoir les créer?
+-   Et y a-t-il des informations financières / budgétaires sur des
+    cartes?
+-   Combien de fois avez-vous revu Kibera pour la cartographie au fil
+    des ans pour maintenir la carte à jour?
+-   Lucy - vous travaillez avec MapKibera depuis 2009! De votre point de
+    vue, comment les attitudes envers l'OSM ont-elles changé au Kenya
+    depuis lors? Comment avez-vous adhéré au gouvernement local?
+-   Et si les donateurs retiraient tous leurs fonds. Le public
+    pourra-t-il / pourra-t-il continuer à cartographier (de façon
+    "hobby"?)
+

--- a/sessions/qa/M9WYW9.md
+++ b/sessions/qa/M9WYW9.md
@@ -1,0 +1,54 @@
+---
+layout: qa
+title: "The State of OpenStreetMap in Africa"
+code: "M9WYW9"
+---
+
+Add questions here
+
+
+1.  **Did the video start at the begining?**
+    1.  * no, unfortunatelly due to technical issues, the first few
+        minutes of the talk were not streamed. the speaker also does the
+        presentation live, because for related technical reasons, the
+        pre-recorded video could not be played back. sorry for the
+        inconvenience - sotm team*
+    2.  Hmm, have him upload a final version soon, perhaps.
+2.  **Is there an official OSM Morocco association?**
+    1.  There is an official OSM Morocco association with a few
+        contibutors but not a real community
+3.  **Has it gone off again?**
+    1.  It stopped for me.
+    2.  +1
+    3.  +1
+    4.  +1 Enock
+    5.  Audio 's tab is working
+4.  **Is there a link to the video anywhere?  And the slides?**
+    1.  ... yes
+    2.  It will be very useful if the survey data or slides can be
+        shared somewhere
+5.  How many people were surveyed and how did you reach out to them? I
+    may have missed this in the talk.
+6.  Do you have any data on gender?
+7.  And any data about what is being mapped?  Particularly urban vs
+    rural?  % Mapping for particular purposes ie flood resilience,
+    malaria etc
+8.  How can the OSM better community support the community in Africa?
+9.  Which governments have been particularly supportive of OSM?   and
+    which particularly unsupportive (if you are able to say publicly?)
+10. This list of challenges is great.
+11. Whats the state/progress of having OSM Africa communities being
+    official OSM chapters under the OSMF(we are at zero at the moment)
+    What are the barriers? He just answered :)
+12. Interesting about who had/hadn't applied for the Microgrants. Do you
+    think Microgrants will be an important thing for the OSM Africa
+    community in future?  Only if people are members of OSMF!
+13. // I think there is a misconception about Free and Open Source
+    (quality of free not good? maybe?)
+14. Is it possible to have chapters not require a bank account. This is
+    a primary hindrance to chapter formalization. It requires
+    incorporation which can be onerous, and potentially undesireable.
+    1.  **No -** Enock - why? indiebio financial record ? How do they
+        manage funds? - Enock
+15. What are you on the challenges facing to sustain volunteers?
+

--- a/sessions/qa/MJ8ZY8.md
+++ b/sessions/qa/MJ8ZY8.md
@@ -1,0 +1,72 @@
+---
+layout: qa
+title: "OSM Routing Evaluation"
+code: "MJ8ZY8"
+---
+
+**Add questions here**
+
+
+-   Ah, (my thought's from Mustard's introduction:) so by putting
+    routing on OSM.org, OSM has made a conscious decision to go beyond
+    just being a data creator. (Good.).
+    -   Yantisa: Indeed, and I would love to see OSM communities use and
+        develop routing (engine&data) that is best suited for their
+        area.
+-   Funny route choice: avoid all police stations.
+    -   Yantisa: yes, true that! It is possible to make a route that
+        avoid all police stations, especially all police station already
+        well mapped ;)
+-   Are the pedestrian ways and sidewalks well mapped on the area you
+    evaluated? It's good to consider the connectivity of pedestrian ways
+    to streets on this study.
+    -   Yantisa: It depends, in Jakarta metro areas, the pedestrian is
+        currently being well developed and tactile paving is starting to
+        get common. In terms of mapping, these sidewalks is far from
+        complete. In my scenario 2 talk, some of the sidewalk have been
+        mapped (<https://overpass-turbo.eu/s/VMN)>. Unfortunately as you
+        move outwards, pedestrian and sidewalks are not that well
+        developed and not yet mapped.
+-   How does OSRM prioritize in terms of road class? One wouldn't want
+    to find themselves in dust tracks because it is a shorter distance.
+    -   Yantisa: Just a disclaimer that I am not really familiar with
+        OSRM, I do quite familiar with Graphhopper (GH). In GH, the
+        higher a road classification it gets more priority. So motorway
+        get the highest down to tracks as the lowest. More about road
+        classification in OSM:
+        <https://wiki.openstreetmap.org/wiki/Key:highway>
+-   Are crime areas a concern?
+    -   Yantisa: As far as I know, in default, the routing engine did
+        not put it into consideration. Yet, it is fully possible for
+        routing engine to avoid certain areas in their routing
+        calculations.
+-   Any specific attributes that we need to put into, to improve route
+    for all of three route provider?+2
+    -   Yantisa: Yes, road classification is the first one because it
+        gives information to routing engine on which road to prioritize.
+        Other tags will be quite useful, such as maxspeed, oneway or
+        access restriction. Here is a good page that give more
+        information:
+        <https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing>
+-   Does Gojek (your company) use OSM for routing?+1
+    -   Yantisa: we are currently still evaluating to adopt OSM and
+        several other data sources as well as routing engine, stay tuned
+        for any updates ;)
+-   How does OSRM collect route data? is it done in participatory?
+    -   Here are the tags that OSRM uses:
+        <https://taginfo.openstreetmap.org/projects/osrm#tags> -maning
+    -   Take note, \`highway=track\` is not used by OSRM. -maning
+        -   Yantisa: thanks a lot, Maning! Ah interesting, since
+            Graphhopper is still using track in its routing
+            calculations.
+-   Any opinions on Valhalla?
+    -   Yantisa: Initially I want to include Valhalla in my comparison
+        but because they did not have easily accessible web demo for
+        routing thus I did not continue. Mapzen does have several
+        interesting technology, Valhalla is one of them. Since Valhalla
+        acquisition by Mapbox, I did not hear any more updates about it
+        in OSM-talk or OSM forum.
+
+
+Yantisa: Thanks everyone for your questions!
+

--- a/sessions/qa/QYYC9T.md
+++ b/sessions/qa/QYYC9T.md
@@ -1,0 +1,82 @@
+---
+layout: qa
+title: "Lightning Talks II"
+code: "QYYC9T"
+---
+
+**Divide and map. Now.**
+
+1.  Why did you pick Postgres instead of MySQL?
+    1.   due to PostGIS extension (a lot can be + by just query) -- qeef
+        1.  Interesting, thank you!
+
+
+Note: <https://www.damn-project.org>
+
+**Mapping Historically Black Colleges and Universities in OSM**
+
+1.  Has there been historically fewer YouthMapper activities or GIS
+    classes at HBCUs, and is that related to the relatively less
+    detailed maps of these institutions? +1
+2.  Have you tried to promote Youthmappers in these colleges?
+
+
+Note: <http://tiny.cc/hbcuosm>
+
+**DDD123-OSM: 2D and 3D render toolchain**
+
+1.  contact details to find more info please  -- indiebio +1 -- Natfoot
+    1.  @jjmontes on Twitter
+    2.  jjmontes&gt; (I asked the question, and followed you on
+        twitter - indiebio ), please reach me by email - will do thanks
+2.  Will there be an Online-3D Map?
+    1.  jjmontes&gt; I'll try to put one up but global coverage seems
+        far.
+
+
+**OSGeo + OSM**
+
+**Tasking Manager 4 Tour**
+
+1.  Do users still need to allow third party cookies?
+    1.  It's optional to allow cookies. That data is only used to
+        provide us stats about the usage of the tools. We use our own
+        analytics instance, so no data is shared with 3rd parties. -
+        Wille
+
+
+**Uses of Mapping for Community Care During the Pandemic**
+
+**OpenStreetMap Data Pacific**
+
+1.  Shouldn't take too long to finish mapping a small island. Then, as
+    we have seen in Germany, the government will start using it.
+
+
+**Hikar.js - bringing Hikar to the web**
+
+1.  F-Droid Version planned?
+    1.  The native Android app could go on F-Droid, yes, but what I've
+        talked about here is a browser-based app.
+2.  I'd be intrested to play with the web app for another location than
+    in Europe and can specify a small location.  -- Natfoot
+    1.  Hi Natfoot, ok great, let me know where you want and I'll
+        populate the server database with it.
+3.  It works in firefox on my windows tablet however the native Sailfish
+    OS browser on my phone gives 'Sorry- Media Device API not supported
+    1.  I'm not familiar with the Sailfish OS browser but I'm guessing
+        that it doesn't support the standard web API for accessing the
+        camera device from JavaScript. Great it works on Firefox/Windows
+        though. BTW the Firefox 'quirk' - on my Android device anyhow -
+        is that occasionally (unpredictably) the augmented data will
+        appear rotated 180 degrees from where it should be. This is a
+        known issue with AR.js as a whole.
+        1.  Thank you, I will investigate the browser further
+
+
+Note: <http://github.com/AR-js-org/AR.js/>
+<https://hikar.org/webapp/>
+<http://github.com/perliedman/geojson-path-finder>
+
+**Mapathon Keralam**
+

--- a/sessions/qa/RANPLK.md
+++ b/sessions/qa/RANPLK.md
@@ -1,0 +1,112 @@
+---
+layout: qa
+title: "Pedestrians First"
+code: "RANPLK"
+---
+
+This talk will describe what makes a city walkable, discuss the
+experience of using OSM to measure walkability, and explore
+possibilities for improving that measurement in the future.
+( <https://2020.stateofthemap.org/sessions/RANPLK/> )
+
+DEMO: <https://pedestriansfirst-southafrica.itdp.org>
+Github: <https://github.com/ITDP>
+  <https://github.com/ITDP/pedestriansfirst> (This is the right
+repository, yes?)
+Email: taylor.reich@itdp.org
+
+
+1.  \[DONE\] How does elevation factor into the evaluation of
+    walkability, as it can often reduce how far can be walked in a given
+    time period?
+2.  \[DONE\] How can I suggest a city to be added? – For example Berlin,
+    Germany.
+3.  \[DONE\] Have you talked to people who have used Pedestrian First to
+    get feedback, do different parts of the world have different amounts
+    of interest in finding walkability?
+4.  Great project and very timely! When you think about/consider
+    walkability do you also consider/take into account that in many
+    parts of the world - streets & their sidewalks are also market
+    places and not only as transit. Great to see you acknowledge it:)
+    Thanks - Anni (rosymaps -chicago)
+5.  \[DONE\] How many people are working on Pedestrians First? Are you
+    working with other groups? - Gregory
+6.  Have you thought of building a pedestrian-focused map layer?  In the
+    same way there is opencyclemap, for example+1+1
+    1.  Taylor: I haven't thought about this! I don't know what it would
+        mean - email me! taylor.reich@itdp.org
+    2.  Will do, but it's mostly a tile set which emphasizes pedestrian
+        features rather than car features, <https://opencyclemap.org/>
+7.  \[DONE\] Do you engage with local communities/mappers or rely soley
+    on the OSM Data? There are many organised community groups e.g WIEGO
+    who supports informal workers who spend a lot of their time on
+    streets and could be a valuable partner to deepen the map in
+    developing cities. Anni (rosymaps chicago)
+8.  \[DONE\] Any thoughts on walkability and security: In a lot of
+    African cities... maybe all cities aound the world, a lot of violent
+    attacks occcur along pedestrian walks..making a lot of people in
+    this cities to prefer other modes of transport.
+
+
+Comments:
+
+1.  Oh look, this store owner has cordoned off this typical Taiwan
+    sidewalk: <https://goo.gl/maps/Hh45xQZyX3W4YXYc8> and even AI tools
+    won't get the goverment to enforce the "laws" -jidanni
+    1.  Often they even eat up one traffic lane too. So sidewalk eaten,
+        and people + cars share the only remaining lane. So sure
+        sidewalks exisit (underneath the buildings they put on top of
+        them.)
+2.  All that detail is great. But if **carto (the default OSM map
+    style)** doesn't render it or allow zooming to it, "why should I map
+    it?"
+    1.  OSM is a database, there are many ways to render the data, not
+        just carto. For example a smartphone app may be more appropriate
+        to navigate and they consume tags not visible in carto.
+        1.  Well Joe Public goes to OSM.org for his impression of "OSM".
+3.  Placing items too close to roads gets them eaten in **<span
+    class="underline">carto.</span>**
+    1.  ahhh -- you mean, like people mapping sidewalks and sidewalk
+        amenities? or are you talking about the data coming out of Peds
+        First?
+        1.  E,g,, tourist points of intrest. Too near a road: boom,
+            eaten. GitHub issue response: well (in the west) things are
+            never that close to roads. Electric poles also end up
+            rendered "embedded" in roads they are on the side of (when
+            we edit them).
+        2.   That definitely sounds like a problem. We're not doing
+            anything on the OSM data collection side - although we could
+            be interested in some mapathon collaborations! - we just
+            take the data from OSM and use it :)
+
+
+<span class="underline">Questions from Taylor for the audience:</span>
+
+1.  Can you imagine using Pedestrians First in your city? If so, how? In
+    what role?
+    1.  My city is already walkable and transport statistics show it as
+        an important transport for work etc. Post-Covid19 there are
+        changes to encourage further walking routes
+    2.  Yes, I've been exploring something similar to look at how
+        Liverpool (where I live) could become a "15 minute city". 
+        That's bikes as well as walking, but mapping the amenities is
+        something I want to add to it - <http://15minutecity.mcqn.com/>
+    3.  Japanese cities tend to prioritize pedestrians more than before.
+        (Nefore they didn't even have many sidewalks)
+        1.  My city (Nishinomiya city) is functionally compact, and due
+            to the effects of covid-19 I haven't boarded a car or train
+            for three months.
+2.  Do you have any suggestions for how we could improve Pedestrians
+    First, either through OSM or other data sources, especially to
+    measure street-level walkability?
+    1.  Commonly available tags such as speed linit and lanes help
+        calculate crossability for pedestrians+1
+    2.  Further pedestrain tags perhaps that reflect details of how
+        accessible a road or route is, we could use living streets or
+        lighting to highlight safe streets for walking. Tags on road for
+        pavements (side walks).+1
+
+
+AUDIO BREAKING UP
+Audio gone
+

--- a/sessions/qa/RHDUV9.md
+++ b/sessions/qa/RHDUV9.md
@@ -1,0 +1,163 @@
+---
+layout: qa
+title: "An Incomplete History of Companies and Professionals in OpenStreetMap"
+code: "RHDUV9"
+---
+
+1.  Add questions here
+
+Please feel free to start writing questions before the end of the talk
+and remind to rename yourself :)
+
+Speaker: Mikel Maron  (@mikel)
+Chair: Lorenzo Stucchi (@LorenzoStucchi)
+
+**Questions:**
+
+1.  \[FAIT\] Au début, les sociétés étaient bonnes pour le financement.
+    Maintenant, OSM (F) & HOT peut distribuer des microgrants afin que
+    les bénévoles ne dépendent pas directement de l'argent des
+    entreprises, est-il préférable d'avoir cette séparation? - Gregory.
+2.  \[FAIT\] Devrions-nous faire une distinction entre les sociétés à
+    but lucratif et les sociétés de principe? Et entre les individus des
+    sociétés vs les actions officielles des entreprises? –M! Dgard
+3.  \[TERMINÉ\] Si nous nous consacrons à la modification de nos cartes
+    de volontariat, pouvons-nous ou devons-nous trouver des lieux de
+    travail qui contribuent à l'OSM. Avez-vous des suggestions sur les
+    personnes à approcher? - Natfoot - Merci pour la réponse
+4.  \[FAIT\] Pourquoi pensez-vous que les entreprises et les sociétés
+    n'investissent plus dans l'amélioration du cœur d'OpenStreetMap,
+    mais investissent plutôt dans la cartographie et le développement
+    d'outils tangentiels? - Ilya +4
+    1.  bonne question, mais à mon humble avis, la contribution au cœur
+        de l'OSM est très difficile en raison de la résistance de
+        certains portiers
+    2.  Hmmm, Mapbox <s>finance</s> + a financé + le développement d'iD
+        qui je pense est un outil de base
+        1.  Pour mémoire - je ne pense pas que l'un des principaux
+            contributeurs iD soit payé par Mapbox ces jours-ci.
+            --RichardF
+    3.  C'est un peu plus nuancé que cela - la façon dont OSM fonctionne
+        (à l'heure actuelle) est un noyau super efficace et un
+        écosystème super lâche. Vous ne pouvez pas avoir un écosystème
+        créatif et lâche si le noyau continue de tomber. La raison pour
+        laquelle le noyau ne tombe pas, c'est parce que les responsables
+        du noyau ont des normes (très) élevées, et c'est cette stabilité
+        qui permet l'énorme écosystème créatif. Et le maintien de ces
+        normes élevées peut être interprété comme un «contrôle d'accès»,
+        mais je ne pense pas vraiment que ce soit l'intention. Cela ne
+        veut pas dire qu'il n'y a pas de place pour l'amélioration, bien
+        sûr que oui, mais je pense qu'il est important de reconnaître ce
+        qui fonctionne (et fonctionne vraiment bien) dans la
+        configuration actuelle. --RichardF
+5.  Y a-t-il un lien vers les diapositives et les liens que vous
+    mentionnez?
+6.  \[FAIT\] "Les entreprises ne veulent pas d'OSM, les gens veulent de
+    l'OSM" - mais n'y a-t-il pas un risque que la production négative
+    globale d'une entreprise éclipse quelque chose de bien qu'elle
+    pourrait faire pour / à l'OSM? Devrions-nous nous engager même avec
+    de telles entreprises? - Frederik +2 Enock -
+    1.   donner des exemples? geofabrik?
+    2.  Je pense que Facebook est l'enfant de l'affiche pour
+        l'entreprise soutenant l'OSM avec une réputation négative à la
+        fois à l'extérieur de la communauté OSM et à l'intérieur (voir
+        leur cartographie d'IA bâclée en Thaïlande). +1 - nommez un
+        autre exemple que &lt;- Egypte
+        1.  à quoi ressemblerait une évaluation factuelle?
+7.  \[TERMINÉ\] À qui s'adresse cette conférence? -Corey Dickinson
+    1.  n'était pas censé être provocateur, juste curieux :)
+8.  \[FAIT\] Pour les entreprises qui sont de mauvais acteurs, comment
+    les identifier et comment les traiter? - Gregory +5 Enock
+    1.  De la même manière, vous traitez avec des contributeurs
+        individuels qui sont de mauvais acteurs. -Ian
+9.  Comment en sommes-nous arrivés à de grandes entreprises exigeant que
+    tous les commentaires de l'ensemble de modifications passent par le
+    service des relations publiques? -- Il y a
+10. **Pouvez-vous donner un seul exemple de quelqu'un disant que toutes
+    les entreprises sont un monolithe? Ou qu'ils sont toujours mauvais.
+    Un seul s'il vous plaît. - +1 anonyme Enock**
+    1.  Veuillez lire les minutes du conseil d'administration des
+        dernières années. - Lien ou ce n'est pas arrivé. - Les réunions
+        n'ont pas été enregistrées ni les courriels pour diffusion
+        publique. -heather - qed
+11. \[FAIT\] Quel est le secret pour demander / dire quoi que ce soit à
+    Google ou Facebook? Ils sont trop gros pour entendre la personne
+    moyenne. "Appuyez sur le bouton de rétroaction" Ha ha ha. La seule
+    façon est que les médias fassent des histoires auxquelles ils
+    doivent répondre.
+12. \[TERMINÉ\] Que pensez-vous de la façon dont certaines entreprises
+    allemandes ont pris par le passé? Ils ont visité les réunions
+    locales, souvent mensuelles, dans les villes et les régions de la
+    communauté de l'OSM afin d'apprendre comment fonctionne l'OSM.
+13. \[Terminé\] Où avez-vous obtenu ce chapeau? --RichardF +4
+14. \[TERMINÉ\] Quand est-ce que l'historique complet arrive :)? - Enock
+    1.  et pourquoi n'écrivons-nous pas simplement une histoire de
+        collaboration - bruyère +2
+15. \[TERMINÉ\] Avec plus d'une cartographie au sol - le renforcement de
+    la communauté sur le terrain - au-delà de l'osm humanitaire -
+    comment l'OSM voit-il le rôle du bénévolat des communautés locales
+    pauvres?
+16. Quelle est la prochaine grande chose à l'horizon de l'OSM?
+
+
+**Commentaires:**
+
+1.  Hahaha! :) (Belle ouverture) +5
+2.  Utopie socialiste!
+3.  Peindre Geofabrik comme une entreprise insidieuse est soit un coup
+    de génie, soit un point de combat inutilement
+    1.  Je pense qu'il plaisantait.
+4.  Si vous n'avez pas regardé le discours SOTM US 2014 de John F. -
+    c'était incroyable en termes de réflexion sur la négociation et la
+    collaboration. Toute la conversation m'a donné une fenêtre sur la
+    façon dont nous pourrions être une communauté et un projet plus
+    sains. - <https://vimeo.com/91877574>
+5.  Je veux une bataille épique de l'histoire du rap entre Mikel et
+    Frederik - M! Dgard +102159265359 (les mathématiques sont
+    difficiles, yo!)
+    1.  C'est drôle parce qu'à un SOTM tout le monde a fait que Steve C
+        et Mikel se battent, je pense, se jetant de l'eau? Maintenant,
+        Mikel mène avec Steve sur son discours
+    2.  Réponse officielle de Frederik sur IRC: "\[vous\] auriez
+        simplement pu vous connecter aux précédentes réunions du conseil
+        d'administration de l'OSMF"
+        1.  Oui, ça a été deux ans de ma vie - réunions du conseil
+            d'administration et courriels - Heather
+6.  "Pouvez-vous lui parler?" Non, je peux lui envoyer un message. "Quel
+    est son prénom?" Il s'appelle Mikel. "Il ressemble à Mousey de
+    Moana." - RichardF et SebastianF (4 ans) Oui bonne coupe de cheveux
+    en lock-out! HAHAHAH
+7.  Pourquoi OSM ne passe-t-il pas plus de temps à réfléchir à la
+    manière dont les autres projets «ouverts» équilibrent les intérêts
+    de l'entreprise et de la communauté / du projet J'ai défendu cela
+    plusieurs fois, mais on m'a souvent dit que «OSM» était différent.
+    Je suppose que je dis qu'il est temps d'être «fondé sur des preuves»
+    dans la façon dont nous modifions le projet. - Heather Oui! + 3
+    1.  Ici pour la première fois, venant d'un autre projet (KDE), la
+        discussion semble assez familière, certainement pas un problème
+        unique pour OSM je dirais - Volker +1 - des défis similaires
+        dans Debian - indiebio
+        1.  Pour moi, les problèmes avec les entreprises sont d'avoir un
+            monopole, alors que nous avons une diversité d'entreprises
+            et de bénévoles, les choses ont tendance à bien fonctionner.
+            Les logiciels libres ont eu beaucoup de problèmes lorsqu'ils
+            étaient dépendants d'une seule entreprise (comme Sun, Oracle
+            ...)
+8.  J'adore voir la carte de Jennings! - Corey +3
+    1.  Yay Jennings! +1
+9.  Mapbox et Dev Seed ont la même couleur sur cette carte, on dirait
+    qu'elles sont de loin les plus cartographiées mais ne peuvent pas
+    les distinguer (de couse, elles étaient autrefois la même
+    organisation)   <https://works.bepress.com/ljuhasz/20/download> /
+10. 🎩- chapeaux allumés, chapeaux éteints
+11. Même aux États-Unis / en Europe, combien de communautés de
+    cartographie s'adressent aux gens des quartiers pauvres? Essayez
+    d'engager divers cartographes? Partager les outils OSM avec ceux qui
+    n'y sont pas normalement exposés? Loin d'aller ici aussi. + 3
+    1.  Je pense que la partie difficile est de développer un modèle
+        différent pour \* comment \* engager les communautés qui n'ont
+        pas le temps et les ressources supplémentaires ... la question
+        du "café" que Mikel a mentionnée. Nous devons construire cela
+        -Diane
+12. Comment: To us normal folks OSM.org webite = OSM.
+

--- a/sessions/qa/RRVNAM.md
+++ b/sessions/qa/RRVNAM.md
@@ -1,0 +1,245 @@
+---
+layout: qa
+title: "Winds of Change in OpenStreetMap"
+code: "RRVNAM"
+---
+** Nota** : Desafortunadamente, el Q&A no se filmó, pero el audio está
+disponible en
+<https://drive.google.com/file/d/1lDn_z12D8WSLMfCNHRFi7W1YXb61WqpM/view>
+
+**Inglés (principal)**
+<span class="underline">Preguntas para Wi of Change en
+OpenStreetMap</span>
+Tenga en cuenta: para la nota clave no habrá tiempo para preguntas.
+Allan va a hacer un Q & A como y presidente de la junta OSMF el día de
+hoy a las 19:00 GMT en <https://osmvideo.cloud68.co/user/all-m3n-e6n> .
+Consulte
+<https://wiki.openstreetmap.org/wiki/State_of_the_Map_2020/self-organized_sessions>
+para obtener detalles sobre cómo unirse.
+
+Si lo desea, puede hacer preguntas aquí para que Allan las vea más
+adelante en las Preguntas y respuestas. Agrega preguntas aquí.
+
+1.  \[HECHO\] Me gustaría desafiar la idea de que la descentralización y
+    la visión son opuestas o incompatibles.
+2.  \[HECHO\] ¿Qué lo llevó a concluir que los mapeadores de naves se
+    oponen universalmente al cambio, mientras que las partes interesadas
+    comerciales quieren un cambio universal?
+3.  \[HECHO\] ¿Cómo se asegura de que las "voces fuertes" no descarrilen
+    el progreso?
+4.  ML / AI: ¿No comenzaron todas las áreas con vastas áreas no mapeadas
+    y pocos contribuyentes? En la vida real, esperaría que las
+    características asignables escalen con la población, al igual que
+    con los posibles mapeadores.
+5.  \[HECHO\] Voces altas: ¿hablaste con voces que no eran fuertes en
+    tus charlas? ¿Cómo elegiste con quién hablar y con quién no?
+6.  \[HECHO\] Usted señala que el peso de la opinión / voz de alguien no
+    debe definirse por su "soltura": ¿cuáles cree que deberían ser los
+    criterios para decidir qué peso le dan a una opinión / voz aquellos
+    que están en una posición de ¿tomando decisiones?
+7.  \[HECHO\] Cuando dices "la comunidad", ¿incluyes voces corporativas
+    en eso?
+    1.  Me encantaría escuchar la respuesta a eso. La charla parece
+        implicar que la respuesta a eso es 'sí'.
+    2.  "Mi opinión es que la comunidad está formada por todos los que
+        creen que están en la comunidad. Cuando contribuyen. ¿Tienen una
+        voz más grande? No. ¿Prevalecerá su POV? Probablemente no, la
+        comunidad es bastante grande".
+8.  \[DONE\] Allan says that the full SWOT analysis can be found on the
+    Wiki, and that he can send it by email. Is the full analysis the
+    same as <https://www.openstreetmap.org/user/apm-wa/diary/392767>, or
+    are there additional resources to review?
+9.  \[DONE\] Regarding role of businesses in OSM: on one hand we have
+    the extreme example (as far as I know, to date without a
+    satisfactory resolution) of GlobalLogic who directed financial
+    resources to gain voting power in OSMFB. But we also have a lot of
+    other companies whose intentions are less obvious - either because
+    they are in fact less nefarious, or because, learning from
+    GlobalLogic's example, they are spreading their OSMF membership
+    registration more thinly so that even the amazing Membership WG
+    can't pick it up. Personally, I believe the reason OSM is so great
+    is that it is not motivated by money,  but driven by volunteers. I
+    oppose corporate involvement in OSM and OSMF not just under the
+    GlobalLogic model, but also more apparently benign models (such as
+    having employees of companies benefitting financially from OSM
+    sitting on OSMF board). As someone more articulate than me put it,
+    "If the OSMF (...) allows GlobalLogic or any other corporation to
+    take over OSM for its own purposes, all my mapping work to that
+    point, intended to benefit a much larger community, will have been
+    for naught, and they idea that my work will then benefit only
+    GlobalLogic will make me rather angry."
+    (<https://lists.openstreetmap.org/pipermail/osmf-talk/2019-February/005953.html>
+    ). <span class="underline">So my question is:</span> what measures
+    can we have in place, what is being done, what can I do, to ensure
+    the OSM project continues being open and volunteer-driven, while
+    allowing for a healthy relationship with powerful corporations?
+    1.  Empower local chapters and communities.
+    2.  These companies understand our volunteer-driven model and do not
+        want to touch the spring of this data they're using and valuing.
+        A bigger threat might be someone from *outside* that group.
+10. \[DONE\] You mention white male dominance in your talk - does this
+    (race and sex/gender) in your opinion constitute the most severe or
+    the most significant dimensions of the lack of diversity in the OSM
+    community?
+    1.  "I don't know the answer to that question. I would argue that
+        geographic diversity is probably as important. We need more on
+        the grounds activity and communities on the ground to protect
+        the foundation from a hostile takeover."
+11. \[DONE\] You are speaking of 'opposition to machine learning and
+    artificial intelligence in Western Europe'.  Could you elaborate on
+    what this refers to?  Is it possible that you have misunderstood
+    opposition to a certain practice of using technology to generate
+    data with questionable connection to the observable reality and no
+    or limited control of the mappers over the technology as principal
+    opposition to a technology in general here?
+    1.  "I talked to people in Europe and also in East-Asia, South-Asia,
+        Africa, Latin-America. In these latter regions I did not hear
+        this opposition. In fact, in some places, these tools are even
+        viewed as necessary. In Europe there's a stronger focus on
+        individual mappers."
+    2.  "I don't think I misunderstood. I think the key is that it has
+        to be a decision of the local community. If they can assert
+        quality control. E.g. checking that ditches and roads are
+        correctly classified. I think it's more a question of who's in
+        control of the map. And the local mappers are."
+12. \[DONE\] Re. Vector Tiles - have you asked current developers of
+    community map styles on input on the future of community map
+    design?  What map users want is one thing, priorities and needs of
+    qualified volunteers is another.
+    1.  Do you consider the OSMF paying people for work in that domain?
+        +1  naveenpf
+    2.  "There are a lot of questions we and the community need to
+        answer before we can move forward on this. E.g.: what should
+        they look like, should we compete with commercial providers..."
+13. \[DONE\] What are you thoughts on Usergroup instead of Chapter ? In
+    some countries running a govt approved legal entity like chapter is
+    very difficult  ? -- naveenpf
+    1.  "We've talked about that. We're going to look to the local
+        commnities to tell us how they want that to happen. India isn't
+        the only place this is happening. Local communities should talk
+        to us, if local chapters aren't going to work, tell us what
+        will."
+    2.  "if you would like work to happen on a "local chapter light
+        version", please join the LCCWG it's on our agenda there" -
+        Joost
+14. *\[DONE\] "If there is a common goal, then conflicts can be
+    solved."* —Eli Goldratt, father of the Theory of Constraints - What
+    is the common goal of the OSM?
+    1.  "There's a line on the OSMF website: "We want to create a map of
+        the world that everyone can use". Or a database, as Frederik
+        said, but that's less understandable, so we go with a simplified
+        phrase. But this is the common goal. I agree with Frederik on
+        that."
+15. With each imagery set several meters different than each other, the
+    more we edit the more damage we do to the map. So yes please get
+    some  "good datum imagery" that we can finally edit with.. (Maybe in
+    developed countries this is not a problem.)
+    1.  "Yes, please, this drives me crazy too. The imagery is all
+        donated. It has to do with the orthorectification which is not
+        100% accurate. This is why you can drag backgrounds in the
+        editors. This is why I'm glad that in Turkmenistan I collected
+        an aweful lot of GPX traces. I'm not sure there is a solution to
+        this, this is a complex technical issue."
+    2.  Yes I slide the maps... damaging it even more...
+
+**\[Questions asked during the Q&A with Allan are below this point\]**
+
+1.  \[DONE\] Do you have a breakdown of OSMF members by country or
+    continent? (asked by Janet Chapman)
+    1.  "No". Altough others pointed out this had been looked at in the
+        past, see [<span
+        class="underline">https://www.openstreetmap.org/user/imagico/diary/391322</span>](https://www.openstreetmap.org/user/imagico/diary/391322)
+    2.  Follow up question: Should the board ensure that all continents
+        are represented then? (in the board) - Janet
+    3.  I worked in government that had de facto quotas, and it never
+        really worked. I would rather see a more organic growth in the
+        geographic diversity of the board. I would like to see more
+        people in the special groups we're setting up and then have them
+        run for the board too.
+2.  \[DONE\] What are the "threats" to OSM in the future? E.g.,
+    Presidential order shutting it down., Evil empires' troops secretly
+    deleting edits, etc. Anything? Legal action from Google for who
+    knows what. Better back it up in several different jurisdictions.
+    1.  I don't see threats from Google or the other empires trying to
+        shut us down. The threats I see is a hostile takeover from
+        someone in the corporate area that isn't yet part of our
+        ecosystem and doesn't understand that a hostile takeover would
+        damage our project. I don't see any likely threats.
+3.  \[DONE\] Do you think that the OSM intellectual property is not
+    currently protected enough from your comments in the talk earlier? -
+    Guy
+    1.  "I think from a legal standpoint it's protected well enough.
+        This is something where the local chapters can be helpful too. A
+        local chapter came to us for permission to sue an entity that
+        was violating our license. I think this is a good thing."
+4.  \[DONE\] What about sovereign or national threats to OSM - are these
+    a possibility in your opinion? - Guy
+    1.  "I suppose it's possible that a country could sue us because
+        they don't like something in the data. I think it's a low
+        probability and I think it would be hard for them to do. The map
+        is in a state of flux, it would be easier for them to go in and
+        edit the map and tag it properly."
+5.  \[DONE\] The topic of what should be on openstreetmap.org comes up
+    from time to time - as in should the homepage show something othre
+    than the map (e.g. links to local communities, beginner info, etc).
+    What thoughts do you have on this? Is the Microcosms work in
+    progress the start of something bigger?
+    1.  "I don't really have a view on that. I thought about what
+        Frederik said about that about what they'd done in \[...\], it
+        was pretty interesting. I think that it would be good to have
+        links to the local communities. I find it good that the iD has
+        this information. But should this be on osm.org? I'll leave that
+        to web designers and people who understand this a lot better
+        than me."
+6.  \[DONE\] Gee, you talk like a CEO (and I like that) But CEOs need
+    big salaries. As I understand it you are just a volunteer (good
+    too). So you might say OSM is your "hobby" (good too.)?
+    1.  At a talk I gave at SotM 2016, I explained why I got involved
+        with OSM. It became more than a hobby, it actually became part
+        of my work plan as ambassador in Turkmenistan. \[Link to the
+        keynote: <https://www.youtube.com/watch?v=_t5DxV7cXgQ> \]
+    2.  I'm retired, I can live off my pension.
+7.  \[DONE\] I think we need to have a debate about use of AI in the
+    future of OSM and discuss the benefits to the project - Guy
+    1.  My take is that this is up to the local communities. As the
+        foundation, we don't tell people how to map.
+8.  \[DONE\] I think it would be beneficial to assist with the tedious
+    jobs such as plotting building outlines which take much time but
+    offer advantages perhaps?
+    1.  An armchair mapper drew a highway where there was a creek.
+        There's a place for AI, but that place needs to be complemented
+        with on the ground knowledge. Only a local mapper can tell you
+        whether your assumption about what you're looking at is correct.
+9.  Turkmenistan? Boy I bet they clamp down on their national data bad.
+10. What do you do when you can't zoom in past zoom level XX and can't
+    convince the carto people that people think their mouse must be
+    broken...
+11. The debate re paid mappers is an interesting one that came up last
+    year at the SOTM - with the idea that in developing countries this
+    could be helpful. - Guy
+    1.  My personal view is that OSMF should not pay for mapping.
+    2.  Does that mean you don't support the micro grants? - Erica
+    3.  "No, I support the micro grant system"
+12. What does the next 12 months look like for the board? - Rob
+    1.  Should OSMF have paid staff. We're down to 2 sysadmins, both
+        volunteers. We're looking at 50% growth in data use, what do we
+        need to do so that the platform remains stable and there for
+        what we want it for.  The 2nd priority is the geographic
+        expansion of the community. Thats going to be plenty for us to
+        work on.
+
+
+
+
+**Comments (not questions)**
+
+-   Comment on core values:  Of the OSMF!, OSM:
+    <https://wiki.openstreetmap.org/wiki/How_We_Map>
+-   Ought to have photo of speaker.
+    -   <https://www.openstreetmap.org/user/apm-wa/> Biography at
+        <https://wiki.osmfoundation.org/wiki/Board_Member_Bios>
+-   (Actually he is reading a transcript. Perhaps this can be
+    published.) --&gt; A larger part of the presentation seems to be
+    directly quoting from
+    <https://www.openstreetmap.org/user/apm-wa/diary/392767>
+

--- a/sessions/qa/SAEWDP.md
+++ b/sessions/qa/SAEWDP.md
@@ -1,0 +1,56 @@
+---
+layout: qa
+title: "What to do when local citizens do not consent? A discussion on how to navigate difficult field scenarios that involve local communities."
+code: "SAEWDP"
+---
+
+Presenters: Shamilah Nassozi, Iddy Chazua, Marcel Shabani
+Session Chair: Kathlen Lu
+
+    <https://sdgs.hotosm.org/>   link to resource!!
+
+**Questions:**
+
+1.  \[DONE\] How did you identify the community leaders (who they are)?
+2.  \[DONE\] Were there particular features that the community felt were
+    more sensitive than others?
+3.  \[DONE\] Do you think working with city authorities helped or hurt
+    your attempts to gain trust from communities? +1
+4.  \[DONE\] Are there situations where it's actually better to not map
+    the area, because the (published) data could be used by bad actors
+    (official or others) against the local populace?
+5.  \[DONE\] Would a mapper's papers/documentation help or hinder you?
+6.  \[DONE\] Is it possible to go back to the community with members of
+    nearby parishes to help alleviate their fears?
+7.  \[DONE\] In the DRC are artisnal/illegal lithium mines a factor in
+    people not wanting the area mapped?
+
+
+
+**Comments:**
+
+1.   "entry in a specific jurisdiction felt impossible " Ha Ha Ha,
+    sounds like a polite way to say they were chased out of town.
+2.  Not using real collar clip etc. microphone.
+    1.  So? The recording audio quality seems OK to me. -- das-g
+        1.  Yes, now better.
+3.  Yes the buildings don't have permits. So cannot legally exist,
+    surely. So "please don't make them show up on the map."
+4.  OK, fine. Can't map. Come back with a drone.
+5.  Disguise as grandpa and grandma or some little kids.
+6.  OK, don't let us map. Fine. No paving your roads or telephone line
+    installation this year.
+7.  You are creating open data, so tomorrow the city will be using it,
+    just like the residents feared. So never mind saying you are a
+    different group.
+8.  I think doing participatory mapping, but with local people (not
+    necessearily local leaders) may help. Additionally, I've found
+    including local residents in decision-making (e.g. where can vs.
+    can't map, what data points are collected) helpful.
+9.  Yes showing up surveying means their land was sold, usually. So
+    folks will fear.
+10. Need town meeting and posters: XXX surveying project. July XX, 20YY.
+11. Need big dinner party for the whole town. Prize draw.
+12. Sounds like a one-day survey turned into a week-long PR effort,
+    seven times more work.
+

--- a/sessions/qa/SNEDXL.md
+++ b/sessions/qa/SNEDXL.md
@@ -1,0 +1,59 @@
+---
+layout: qa
+title: "Evolution of humanitarian mapping within the OpenStreetMap Community"
+code: "SNEDXL"
+---
+
+Talk (in the program):
+<https://2020.stateofthemap.org/sessions/SNEDXL/>
+Abstract in the proceedings of the SotM 2020 Academic Track:
+<https://doi.org/10.5281/zenodo.3923064>
+Full proceedings of the SotM 2020 Academic Track:
+<https://zenodo.org/communities/sotm-2020>
+
+**Add questions here**
+
+1.   \[ANSWERED\] How do you determine if a building or a highway is a
+    contribution by HOT Tasking manager? Are there tags at the data like
+    in the changeset comments like \#missingmaps or \#hotosm? Maybe you
+    said that and I missed this part of information -- Susanne SB
+2.  \[ANSWERED\] How did you count mapping vs validation activities?
+    number of users? features? edits? -- Serena. Thanks, I agree a tasks
+    is a suitable unit of comparison.
+3.  \[ANSWERED\] The OSHDB framework was created in order to facilitate
+    performing OSM history-based analysis by non-developers, e.g.
+    researchers. Do you have an estimation of how many people are
+    currently using it? -- Marco Minghini
+4.  \[ANSWERED\] Has your study show any impact on OSM mapping during
+    the current pandemic? -- Serena
+    1.  this blog post shows a record in mappign on OSM, and TM projects
+        are related
+        <https://blog.openstreetmap.org/2020/06/30/a-new-record-for-daily-mappers-and-new-users/> -
+        wille
+5.  \[ANSWERED\] Are you aware of studies (or have possibly conducted
+    one yourself) investigating possible differences regarding mapping
+    behaviours between humanitarian mappers and 'ordinary' mappers also
+    beyond specific actions/tasks? Are HOT mappers mapping different
+    kinds of features in possibly different ways? -- René
+6.  \[ANSWERED\] Sort of implied by the numbers/graphs, but not exactly
+    formulated as such. But would you conclude that initiatives like
+    HOT/Missing Maps are successful drivers for mapping participation?
+    -- YaguraStation
+7.  \[ANSWERED\] Was this study asked by HOT? if no, did you get their
+    feedback? -- Marco Minghini
+8.  \[ANSWERED\] Have you included several Tasking Managers used for
+    humanitarian purposes (like HOT TM Indonesia or Tasking Manager of
+    Les Geographes Libres (francophone movement), or is it only an
+    analysis of one TaskingManager, the principle HOT Tasking Manager?
+
+
+**Comments**
+
+-    I like the diagram that puts humanitarian mapping activities in
+    context - nice overview -- Serena
+
+
+
+**OSM Science Mailing list**:
+<https://lists.openstreetmap.org/listinfo/science>
+

--- a/sessions/qa/SPRQVZ.md
+++ b/sessions/qa/SPRQVZ.md
@@ -1,0 +1,115 @@
+---
+layout: qa
+title: "Curious Cases of Corporations in OpenStreetMap"
+code: "SPRQVZ"
+---
+**<span class="underline">Curious Cases of Corporations in
+OpenStreetMap</span>**
+Abstract in the proceedings of the SotM 2020 Academic Track:
+<https://zenodo.org/record/3923050>
+Full proceedings of the SotM 2020 Academic Track:
+<https://zenodo.org/communities/sotm-2020>
+
+
+**Add questions here**
+
+1.  \[ANSWERED\] If mapper A maps a way, and corporate mapper B cuts the
+    way in two, do you count those ways as created/last edited by A or
+    B? - Guillaume Rischard
+2.  \[ANSWERED\] HOT has done for-pay mapping, and has employed people,
+    why did you not look at that?
+3.  \[ANSWERED\] With the Grab/Singapore editing, are all those
+    restrictions actually necessary? One common problem in the past is
+    companies adding unneeded turn restriction relations e.g.
+    no\_right\_turn into a no-entry oneway road. --Andy Allan
+    1.  Almost all of them seem to be no\_u\_turn:
+        <https://taginfo.geofabrik.de/asia/malaysia-singapore-brunei/keys/restriction#values>
+        which seems to be used for a continuous centerline on a road
+        (counter-example:
+        <https://www.openstreetmap.org/relation/9041006> )
+4.  \[ANSWERED\] Have you looked at size of mapping teams per company,
+    and how that has changed? Rather than looking at edits per company.
+    -- Gregory.
+5.  \[ANSWERED\] How likely do you think it is that these hyper-niche
+    mappers will stay around to map more things outside of their narrow
+    interests? do you have any data that shows they have any rates of
+    retention? --corey
+    1.  thanks!
+6.  \[ANSWERED\] Some corporate mappers are mapping part time for a
+    company and also do volunteer mapping on their own. The changesets
+    are generally differentiated by the presence of a changset hashtag
+    if the mapper uses the same OSM user account. Do you account for
+    this difference of mapping behavior? (Example: Kaart)  -- Eugene
+7.  \[ANSWERED\] Do you think it's feasable to look at "displacement" of
+    volunteer mappers? Questions like: does a heavily corporate-mapped
+    area have a higher tendency to loose other mappers? Or do they shift
+    their attention? Or does the (hopefully) increased data quality
+    bring more people who are interested? -- Joost
+8.  \[ANSWERED\] Anything you are willing to say about Google on the
+    topic of corporate mapping? I know it might not be relevant. --
+    Anonymous
+9.  \[ANSWERED\] Do you have statistics/sources on where the
+    corporations' paid mappers are based, geographically? --Tobias
+    1.  Lyft had an OSM mapping office in Seattle, I'm not sure if it's
+        still open.
+10. \[ANSWERED\] What about outsourced mapping companies, like,
+    GlobalLogic? -- Eugene
+11. Question? – Name
+
+
+**Add comments here**
+
+
+-   Your globe looks really cool +3
+-   HERE Maps hire data digitization companies to populate OSM for them,
+    periodically importing this data into their own platform
+-   There was also a map roulette challenge for tesla parking aisles
+
+
+Boy I sure hope they use perfectly aligned imagery....
+else
+those
+parking
+lanes
+will
+end
+up
+down
+here. -jidanni
+
+-   Maybe they used gps traces instead of imagery.
+    -   GPS bound to be even worse!!! Unless they got something better
+        gear than we home mappers have.
+
+
+
+-   All I know is with imagery +-5 meters offset, any such mapping will
+    just do more damage than good.  OK, so they are certainly not using
+    iD or cellphone GPS traces. OK, so ask them to share their secret
+    tools. -jidanni
+-   Great talk and so important to have this discussion. Looking to our
+    own community - the challenge for us could be to strenghten mappers,
+    editors and validators at all levels - 'remote' and 'local'. perhaps
+    rather than lament the 'niche' mapping of corporations - lets take
+    responsibility, do our bit and find ways to benefit from all the
+    communities in OSM:)  Anni (rosymaps) +1
+-   Nice to see someone is presenting the 3 years in a row :) --
+    Anonymous :)+1
+-   This research has so much potential! OSM should really get on board
+    with these researchers. +3 +2 +1
+-   Don't let <span class="underline">Google</span> put their address
+    database on the map! Else all my friends will be sent to the wrong
+    side of town. -jidanni P.S., you can't get a word in edgewise to
+    Google.
+-   OK, whatever view of WGS84 they are using will now become OSMs, due
+    to their amount of edits. So expect everybody's "craft" edits will
+    have to all move over to align with them. So I sure hope they are
+    not misaligned. -jidanni
+-   I'm saying all this corporate editing is great... if it is perfectly
+    aligned.
+-   Won't OSM end up with twos of things--- wouldn't it be faster for
+    companies to just add a new (second) road, rather than check for an
+    existing road, and edit or at least delete it first?
+    -   response: then they would just make their own map? thats why OSM
+        exists as a data b (shared)ase
+

--- a/sessions/qa/TEAKVH.md
+++ b/sessions/qa/TEAKVH.md
@@ -1,0 +1,43 @@
+---
+layout: qa
+title: "Community mapping a means to building resilience"
+code: "TEAKVH"
+---
+
+Proceedings DOI: <https://doi.org/10.5281/zenodo.3923058>
+
+**This pad is available in the conference presentation**
+[**https://2020.stateofthemap.org/programme/**](https://2020.stateofthemap.org/programme/)
+
+**Questions**
+
+
+1.  Add questions here
+2.  \[DONE\]Thank for your excellent presentation. Did you find any
+    privacy issues regarding uploading collected data on OpenStreetMap
+    platform? - Anonymous
+3.  \[DONE\]Is the Malawi platform for spatial data accessible to
+    everyone like OSM.org? - Anonymous
+4.  \[DONE\]What is the future direction for this reserarch or it is now
+    complete? - Anonymous
+5.  \[DONE\]do this project be used for any vaccination purpose ? for
+    planning vaccination ... - Christian , DRC
+6.  \[DONE\]Are there plans to connect with neighbouring countries and
+    wider OSM community - i.e. a regional map for cross learning - since
+    other countries in the region are also affected by flooding?  Anni -
+    rosamaps (Chicago)
+
+
+**Comments**
+
+
+1.  \[DONE\]Great project that highlights the importance of locally
+    relevant data and how a wide community of residents, academics and
+    government can use this data! Anni - rosymaps
+2.  Great session; many thanks chair and speaker!+1
+
+
+
+**OSM Science Mailing list**:
+<https://lists.openstreetmap.org/listinfo/science>
+

--- a/sessions/qa/URVEBF.md
+++ b/sessions/qa/URVEBF.md
@@ -1,0 +1,45 @@
+---
+layout: qa
+title: "Identify map problems in OSM by connectivity check"
+code: "URVEBF"
+---
+
+Please feel free to start writing questions before the end of the talk
+and remind to rename yourself :)
+
+Speaker: Evan Hossain (
+<https://www.linkedin.com/in/evan-hossain-ab6691a9> )
+Chair: Lorenzo Stucchi (@LorenzoStucchi)
+
+Questions:
+
+1.  \[DONE\] Why do you need a check in \_directed\_ graph? in my
+    validar I've implemented connectivity check using non-directed graph
+    (just ignoring oneway tag), the algorithm to find islands(isolated
+    sub-graphs) becomes much more simple, but results are practically
+    the same  (Kirill aka Zkir)
+    1.  You do not really need to analyze oriented graph. just analyze
+        connectivity. :)
+2.  \[DONE\] Could you explain wrong direction ? (both way seem
+    connected by the same node)
+3.  \[DONE\] Any opensource code repo?  And How We can adapt in other
+    country?
+4.  \[DONE\] User: Transport for Cairo.  Do wrong directions (opposing
+    directions) cause disconnectivity, thus captured by the algorithm?
+5.  \[DONE\] Are you concentrating solely on the car routing (profile)? 
+    -- Stefan K.
+6.  Profiles matter IMHO for pedestrian areas / plazas (with bicycle
+    access, unidirectional) which are a special case for routing
+7.  \[DONE\] How we can use his reversed algorith for COVID ?  make a
+    more social distance ?
+
+
+Comments:
+
+1.   Yup, with all those trees and clouds, there are just a few shreds
+    of roads I can map from imagery.
+    1.  Use LIDAR!
+2.  When you are finished with roads, get to work on house address
+    number quality too...
+3.  You can contruibue all this to iD editor's checker!
+

--- a/sessions/qa/V9J9JS.md
+++ b/sessions/qa/V9J9JS.md
@@ -1,0 +1,15 @@
+---
+layout: qa
+title: "OSM data assessment in the area of Athens - Greece"
+code: "V9J9JS"
+---
+
+Add questions here
+
+1.  what is POIs?
+    1.  Stathis: connection issues. just a moment to get reconnected.
+        thank you
+    2.  POIs: It's the abbreviation of "Point Of Interest": In our case
+        all the shops, restaurants, facilities, tourist attractions etc.
+        All points of OSM that are related to shops etc.
+

--- a/sessions/qa/VJS3LC.md
+++ b/sessions/qa/VJS3LC.md
@@ -1,0 +1,33 @@
+---
+layout: qa
+title: "Mapcampaigner Redesign: The Data Quality Monitor For OSM"
+code: "VJS3LC"
+---
+
+Add questions here Please feel free to start writing questions before
+the end of the talk :)
+
+
+-   Is it a new tool ?
+    -   I discover it this morning but found a lot of issues (some are
+        already described)
+-   We would use it or a whole region or country (i.e. France)
+    -   but Mapcampaigner don't accept large areas 😢
+-   Do you plan to display % also by attributes ? please elaborate more
+    the question
+    -   I want to know of many i.e. names are set for all the OSM
+        objects in the campaign ?
+    -   same thing for another attribute
+    -   (currently you display the completeness for all attributes)
+-   What is the frequency of overpass queries
+-   Is HOT using Map Campaigner currently? Or did you create it mostly
+    for other users?
+-   What is the link to the project you were demonstrating?
+    -   <https://campaigns.hotosm.org/campaign/ebdf88f0f87b4b9996f151601477deed>
+
+
+Comments
+
+-   This is an amazing tool! Thanks for sharing. 👍
+-   thanks too, nice project :)
+

--- a/sessions/qa/VTDQPZ.md
+++ b/sessions/qa/VTDQPZ.md
@@ -1,0 +1,8 @@
+---
+layout: qa
+title: "Closing"
+code: "VTDQPZ"
+---
+
+1.  Add questions here
+

--- a/sessions/qa/XAKBJT.md
+++ b/sessions/qa/XAKBJT.md
@@ -1,0 +1,60 @@
+---
+layout: qa
+title: "Sustainability and OSM for Development"
+code: "XAKBJT"
+---
+
+**Add questions here**
+Contact me at: erica@mapkibera.org
+
+White Paper here:
+<https://opendri.org/resource/sustainability-in-openstreetmap/>
+
+please add your name / OSM username and country if you would like
+
+
+-   **\[ANSWERED\]** "Always more to map" - how did you go about
+    defining what is sustainability for data not just communiy?
+-   **\[ANSWERED\]** "Map or be mapped!" -- can you elaborate on this
+    question?
+-   **\[ANSWERED\]** Do you think the companies working in OSM can be
+    helping local communities map sustainably?
+-   Which local companies in Kenya have you worked with?
+    -   (Anonymous): you may find some examples on
+        <https://mapkibera.org/work/locations/>. Noteably, the page is
+        still loading as I am typing this comment.
+        -   (thanks that's in need of repair)
+    -   And did you have any issues with that?
+    -   Do you do generic(ish) training to ie delivery companies etc on
+        how OSM can help them?  (that could be replicated in other
+        similar places)?
+        -   I wish we had, we've honestly only recently tried to focus
+            on this realistically. It would be a great project for OSM
+            Kenya to do. (Erica)
+-   **\[ANSWERED\] OSM User**: Transport for Cairo (TfC), Egypt.
+    Question: We are an example of a consultancy working with and
+    contributing to OSM in a country where there is no OSM community.
+    What is the relevant "authority" so to speak that allows different
+    contributors and stakeholders to work collaboratively in given
+    country/city?
+    -   Please check out OSM Africa whatsApp group and ask there. You
+        can be added by contacting Geoffrey or me.
+-   **\[ANSWERED\] Guy** - what impact do you see Covid19 having on the
+    sustainability of OSM mapping? Do you see people returning to OSM
+    after leaving (perhaps stage of life or for economic reasons) coming
+    back to support OSM at some future point?
+    -   Sorry!!   :) :)
+    -   Guy - it could be an opportunity or a threat?
+        -   (Anonymous): If mapping there is a job, it may be a threat
+            (I assume this is not the case, but if it is they already
+            have alternative work).
+    -   It could be people on furlough in countries like the UK, who are
+        doing the extra mapping?
+
+
+Happy Independence Day !!
+
+YES!
+
+Thank you - very good talk
+

--- a/sessions/qa/YHEMFS.md
+++ b/sessions/qa/YHEMFS.md
@@ -1,0 +1,76 @@
+---
+layout: qa
+title: "Assessing Global OpenStreetMap building completeness to generate large-scale 3D city models"
+code: "YHEMFS"
+---
+
+**DOI:**
+[**https://doi.org/10.5281/zenodo.3922285**](https://doi.org/10.5281/zenodo.3922285)
+
+**Questions**
+
+1.  <s>Wow! Further reading on tools?</s> found
+    <https://github.com/osmbuildings/>  - YaguraStation
+    1.  (I can't believe how much awesome stuff is going on, so happy
+        :) - indiebio)
+2.  How can we easily estimate building height while mapping? -
+    Anonymous +2
+3.  Can you discuss more about the feature importance for your random
+    forest model in your study in the Netherlands? - ardieorden
+    1.  ANS: number of stories
+    2.  ANS: floor area
+    3.  ANS: complexity of footprint
+    4.  ANS: there's lots of other predictors, but the concern is how
+        available those are globally
+4.  Are cities in the Netherlands very similar for this to work? I could
+    imagine it could be more complicated in countries with old and new
+    cities?
+5.  The examples shown all seem to assume a flat ground level.  Have you
+    also tested estimation for cities on hills? +2
+    1.  Answ: Flat terrain was assumed, as slope is not important in the
+        netherlands. But to transfer, they will look into it. :)
+6.  Can you use building shadows from satellite imagery to predict
+    heights as you will have some buildings as control? +2
+7.  Thanks very much for this very interesting talk! Have you also
+    thought about elevation estimation from earth observation data, such
+    as: SAR data from Sentinel 1 ? Since Radar data might also provide
+    informaitons about building heights, while might be less accureate
+    than 3D point cloud .
+8.  Hello! Thanks and congratulations. Have you tried to apply
+    image-recognition ML models on orthophotos to refine your
+    predictions? I'm specifically thinking of CNN, but any other method
+    also (also see question \#6 and \#9).
+9.  what about estimating building hight with terrain photographs such
+    as Mapillary repository? has it been done? +1
+10. Exeter in the UK has around 35% 3D building coverage of the majority
+    of buildings - it would be a good training set. Combined with other
+    data we could see what works best. See this area for the Met Office
+    as an example:
+    <https://demo.f4map.com/#lat=50.7271961&lon=-3.4753034&zoom=19>
+11. I  believe most of Netherlands have buildings between 1 and 3
+    floors. Isn't the absolute error of 1 floor a bit big for that? --
+    Ilya +2
+12. Did you consider including national regulations on mandated distance
+    spaces into the prediction model?
+13. Isn't the geometry a bit "fuzzy"? some people map very thoroughly,
+    others map basic footprints.+1 nice clarification :)
+14. Can you explain once again how Landsat Raster is being used to
+    predict completeness? ANS: He said they are not using raster data
+    except for monitoring completeness of data  Yes, 2D footprint
+    completeness. He definitely mentioned that!
+
+
+
+**Comments**
+
+-   Looking forward to see if this project will lead to accurate data
+    additions -- Natfoot
+-   I saw the OSM user "Kolossos" at a conference. He presented a budget
+    lidar for crowdsourcing 3-D data at his booth. But I think it's only
+    suitable for small buildings not for skyscrapers.   (I would like to
+    see this talk -- Natfoot +1)
+-   We may be able to use Mapillary to get building height. -- Natfoot
+-   Just my opinion, but it'd be really nice to see how ortophotos
+    improve that... Guys thanks for paying so much attention, learning a
+    lot.
+

--- a/sessions/qa/YTHZWC.md
+++ b/sessions/qa/YTHZWC.md
@@ -1,0 +1,43 @@
+---
+layout: qa
+title: "The Map in 360"
+code: "YTHZWC"
+---
+
+-   Has your t-shirt arrived on time? :)
+    -   which t-shirt?
+-   What are you most excited about now that Mapillary is part of
+    Facebook?
+-   Are there any downsides to being part of Facebook?
+-   The community is "afraid" that Mapillary is now part of Facebook :(
+-   It is possible to increase the position of the photos using the
+    elements present in the photos? In the sense of creating a
+    photogrammetric approach with the 360 images to create a point
+    cloud.
+-   One should mention a problem when armchair mappers use photos
+    without having own knowledge of the place.  You can demotivate local
+    mappers and drive them away from OSM if the armchair mappers use
+    outdated photos.
+    -   what is the question here?
+    -   or just a comment?
+    -   why he does not mention this?
+    -   it's remote mapping not armchair..
+-   Can we remove our photos now so Facebook can't have them
+    -   Facebook could use them before they acquired Mapillary; you
+        granted an open licence
+    -   this would be a silly thing to do, as you granted an *open*
+        licence
+-   Are there any plans to include point clouds (i.e. Lidar data)?
+-   Is there any plan to snap photos to highways (semi)-automatically ?
+-   Are the computer vision models you used open-source? Would love to
+    try it out.
+-   What are the most comfortable/effective 360 camera setups for hiking
+    (capturing imagery on trails/paths)?
+-   How do we invite Mapillary mappers to a country?  I'm thinking of
+    Panamá, where the covering is really poor.
+-   Could you provide help to stitch pictures from DIY 360° camera ?
+
+
+Please feel free to reach me said@mapillary.com or contact
+support@mapillary.com - Said Turksever
+

--- a/sessions/qa/YUM9PY.md
+++ b/sessions/qa/YUM9PY.md
@@ -1,0 +1,82 @@
+---
+layout: qa
+title: "Measuring OpenStreetMap building footprint completeness using human settlement layers"
+code: "YUM9PY"
+---
+
+[<span
+class="underline">https://gisco-services.ec.europa.eu/distribution/v2/countries/distribution/TZ-region-01m-4326-2020.geojson</span>](https://gisco-services.ec.europa.eu/distribution/v2/countries/distribution/TZ-region-01m-4326-2020.geojson)
+
+DOI: <https://doi.org/10.5281/zenodo.3923033>
+Slides: <https://bit.ly/sotm2020-osm-completeness>
+Code: <https://github.com/thinkingmachines/osm-completeness>
+
+Science Mailing List:
+<https://lists.openstreetmap.org/listinfo/science>
+
+(It is considered polite to sign your name to questions.)
+
+**Questions**
+
+1.  \[DONE\] How long were you able to process the whole data in the
+    Philippines? -Feye
+2.  \[DONE\] You assume that the Facebook settlement layer is accurately
+    depicting where built-up areas are. Did you verify that assumption
+    against some known data in the Philippines? -- Frederik (this seems
+    to somewhat conflict with question 4 - i was assuming that Facebook
+    was AI'ing aerial imagery?)
+3.  \[DONE\] You said that building data are required to "know where
+    people live". But if you were e.g. an aid organisation wanting to
+    find out where people live, could you not also look at
+    landuse=residential or highway=residential objects in OSM - since
+    these are easier to add for mappers than tracing buildings? --
+    Frederik +1
+4.  \[DONE\] The settlement layer focuses on mapping population, i.e.
+    populated areas. Some areas have buildings but only non-residential
+    ones, with zero population. Is that an issue for your method? +1
+5.  \[DONE\] Does your method consider the different population density?
+    Some buildings may have 1 storey, some may be skyscrapers, so a
+    pixel in the settlement layer with a certain value for the
+    population may mean different things - the same population can fit
+    in one building or lots of them, depending on the number of floors.
+6.  How difficult is to run your method for all countries?
+7.  \[DONE\] (if time allows) Are you interpolating over the settlement
+    data or assigning pixel-to-area? have you tried interpolation?
+8.  \[DONE\] How do you evaluate Frederik Ramm's statement on volunteer
+    vs. paid mapping, giving you've seen the talk yesterday. With
+    sponsoring stopping, consequently the mapping stopping. -
+    YaguraStation
+9.  \[DONE\] Amazing work! Is it also possible to download the
+    completeness datasets you generated for Phillipines and Madagascar?
+    Would like to see it without going to run your wonderful code.
+    Felix D. And me too please Janet
+10. WorldPop takes into consideration the real population data based on
+    the census (+ projections) and then assigns the 100m pixel value
+    across those admin polygons. Did you consider the same?
+11. \[DONE\] With the results for the Philippines, what are your
+    recommendations for the local OSM community in terms of focus in
+    mapping areas?
+
+
+**Comments**
+
+-   Things on Facebook are never free! They are only useable for those
+    who are its customers and are tracked by it. Since OSM is a free
+    project, Facebook is not a suitable tool for organizing things.
+    Moreover, Facebook breaks the OSM rule and does not mention that its
+    maps are from OSM.
+    -   It is released under cc by 4.0
+-   This is absolutely amazing! This can help our communities identify
+    priority areas as well! **No building left behind!**
+-   Thanks for the talk. There's **Audio-Feedback** during the Q&A from
+    somewhere.
+-   For those who are still interested in an intro to OSM and QGIS (like
+    my lightning talk showed), see this free self-learning material:
+    OpenSchoolMaps - www.openschoolmaps.org - Download PDFs 
+    <https://tinyurl.com/openschoolmaps-zip-download> . -- Stefan Keller
+    -   thank you! - indiebio
+-   Authors are already aware of this, but for the benefit of the
+    audience - another great dataset that can help in such analysis is
+    the Global Human Settlement Layer (GHSL), produced by the European
+    Commission - JRC: <https://ghsl.jrc.ec.europa.eu> -- Marco Minghini
+

--- a/sessions/qa/YXNWNT.md
+++ b/sessions/qa/YXNWNT.md
@@ -1,0 +1,66 @@
+---
+layout: qa
+title: "Buildings are the new Streets"
+code: "YXNWNT"
+---
+
+**Questions**
+
+-   Who is speaking?
+    -   Danijel Schorlemmer
+    -   Felix Delattre
+    -   chair: Miriam Gonzalez (@mapanauta)
+-   If you had to make a prediction, when do you think building data
+    would be mostly mapped? 1 year? 2 years? Or more?
+-   Have you considered this week's release of UK government IDs
+    ("UPRNs") for every "property", as open data?
+-   Could you talk a bit on how you estimate building occupancy from the
+    data (for the ones that are not tagged)? Thanks!
+    -   do you use Infraa-red images for that ?
+-   Privacy is a concern of many, have you considered this, is there a
+    way for people to say "I don't want my building listed" or a way to
+    say, let's use it but anonymise it?
+    -   (But they are from satellites, so not personal?)
+    -   (but they are visible from street ?)
+        -   I didn't say it's logical ;)
+    -   (indiebio: I am interested in metadata, energy use, water use,
+        \[computed\] water harvest or green energy potential from roof
+        area - when does this become a 'privacy' issue? I don't know but
+        this is feedback I have received before...)
+        -    (it's fine, we can leave this for external discussion,
+            thank you)
+    -   For me it is about public good vs private rights, maybe.
+-   What do you consider a building? For example, are
+    temporary/makeshift/informal settlements or buildings under
+    construction considered a building?
+-   What was the thinking behind hosting your code on Debian's Salsa? Is
+    it Debian related?
+    -   Great to see people using it! Open, free, inclusive. :)
+-   You say that you detect tagging errors. Have you thought about
+    giving this back to mappers, so they can fix it?
+    -   do you have examples of tagging errors ? is it just typo?
+    -   (comment: you can give back the errors, not the fixes)
+-   Canada was trying to map all its buildings in OSM by 2020 - do you
+    know if this was achieved or will be finished in the year?
+-   What is your refresh schedule for pulling OSM data?
+-   What is the URL of GitLab / GitHub repository of the project ?
+    -   Or for the project itself?
+
+
+**Comments**
+
+-   Expect big resistance: many buildings in certain countries are
+    actually illegal according to local laws, so will be quite
+    embarrasing...
+-   Comment:
+    -   <https://kiang.github.io/factory_data/>
+    -   <https://kiang.github.io/lands_patrol/>
+    -   are examples of OSM based illegal building reporting sites for
+        Taiwan. (But even the government compares satellite changes, to
+        no result.)
+-   Glad you are putting buildings in their right places (I hope). For
+    me doing it by hand in iD, the offsets due to misaligned imagery are
+    many meters ... which one only finds out years later.  We iD mappers
+    just can't tell which imagery is correct: Bing, Maxar, etc. Flip a
+    coin. (Taiwan.)
+


### PR DESCRIPTION
Since the server that is hosting the session pads will eventually disappear and as we also discussed this during the video review meeting, I gave it a try to produce a static export of the session pads and integrate them into the SotM website. This is basically based on the HTML exports from the session pads that are hosted on the Etherpad-lite instance, which were then converted to Markdown using Pandoc and post-processed using a custom script. Before doing the HTML exports, I went through most of the pads and mostly tried to fix the ordered and unordered lists a bit such that the result doesn't look too broken. I did not try to apply some common structure to the pads though, which might be nice, but would also be a lot more work (if somebody wants to do this, I can easily do another export or provide the scripts I used - it's probably easier to do this in the pads now than in the Markdown files later).